### PR TITLE
Explicitly implemented a move constructor for class DirectoryEntry as

### DIFF
--- a/cpp/lib/DirectoryEntry.cc
+++ b/cpp/lib/DirectoryEntry.cc
@@ -72,7 +72,7 @@ bool DirectoryEntry::ParseDirEntries(const std::string &entries_string, std::vec
     entries->reserve(count);
     size_t offset(0);
     for (unsigned i(0); i < count; ++i) {
-        entries->push_back(DirectoryEntry(entries_string.substr(offset, DIRECTORY_ENTRY_LENGTH)));
+        entries->emplace_back(DirectoryEntry(entries_string.substr(offset, DIRECTORY_ENTRY_LENGTH)));
         offset += DIRECTORY_ENTRY_LENGTH;
     }
 

--- a/cpp/lib/DirectoryEntry.h
+++ b/cpp/lib/DirectoryEntry.h
@@ -47,7 +47,11 @@ public:
         : tag_(other.tag_), field_length_(other.field_length_), field_offset_(other.field_offset_) { }
 
     /** Move constructor. */
-    DirectoryEntry(DirectoryEntry &&other) = default;
+    DirectoryEntry(DirectoryEntry &&other)
+	: field_length_(other.field_length_), field_offset_(other.field_offset_)
+    {
+	tag_.swap(other.tag_);
+    }
 
     /** \brief Constructs a DirectoryEntry from its component parts.
      *


### PR DESCRIPTION
there seem to be compiler differences between the compiler that we use
on Ubuntu and the one that we use on Centos.