### PR TITLE
Now marc_grep, formerly known as marc_grep2, sorts its output.  That is

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,4 +1,4 @@
-PROGS=marc_grep2 jop_grep download_test add_issn_to_articles marc_grep_tokenizer_test db_lookup \
+PROGS=marc_grep jop_grep download_test add_issn_to_articles marc_grep_tokenizer_test db_lookup \
       create_full_text_db add_title_keywords augment_bible_references add_child_refs bib_ref_parser_test \
       bib_ref_to_codes_tool extract_text_from_image_only_pdfs shared_buffer_test delete_ids marc_filter \
       exec_test krimdok_filter resolve_in_path_test enrich_ddcs
@@ -17,10 +17,10 @@ all: $(PROGS) $(CGI_PROGS)
 lib/libmarc.a: $(wildcard lib/*.cc) $(wildcard lib/*.h)
 	$(MAKE) -C lib
 
-marc_grep2: marc_grep2.o lib/libmarc.a
+marc_grep: marc_grep.o lib/libmarc.a
 	$(CCC) $(LDFLAGS) -o $@ $< -Llib -lmarc -lpcre -lcrypto
 
-marc_grep2.o: marc_grep2.cc lib/Leader.h lib/MarcQueryParser.h lib/MarcUtil.h lib/RegexMatcher.h lib/Subfields.h \
+marc_grep.o: marc_grep.cc lib/Leader.h lib/MarcQueryParser.h lib/MarcUtil.h lib/RegexMatcher.h lib/Subfields.h \
               lib/util.h
 
 extract_text_from_image_only_pdfs.o: extract_text_from_image_only_pdfs.cc lib/PdfUtil.h lib/ExecUtil.h lib/FileUtil.h


### PR DESCRIPTION
if multiple tags are being emitted for a record they will now be in
alphanumerical order.