### PR TITLE
Fixed a problem where we did not write out a complete MARC record und…

### DIFF
--- a/cpp/create_full_text_db.cc
+++ b/cpp/create_full_text_db.cc
@@ -66,6 +66,7 @@ void FileLockedComposeAndWriteRecord(FILE * const output, const std::string &out
     if (std::fseek(output, 0, SEEK_END) == -1)
 	Error("failed to seek to the end of \"" + output_filename + "\"!");
     MarcUtil::ComposeAndWriteRecord(output, dir_entries, field_data, leader);
+    std::fflush(output);
 }
 
 


### PR DESCRIPTION
…er the

protection of a file lock.  This had caused mixing of records parts with
those written by update_full_text_db child processes.