### PR TITLE
we can't build "marc_grep_static" on CentOS and don't care anyway, so…

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -3,7 +3,7 @@ PROGS=marc_grep jop_grep download_test add_isbns_or_issns_to_articles marc_grep_
       bib_ref_to_codes_tool extract_text_from_image_only_pdfs shared_buffer_test delete_ids marc_filter \
       exec_test krimdok_filter resolve_in_path_test enrich_ddcs control_number_filter stemmer_test \
       enrich_keywords_with_title_words test_find_substring test_chop_into_words test_auto_temp_file \
-      update_ixtheo_notations update_full_text_db kcdb_info classify_leader07a marc_info marc_grep_static
+      update_ixtheo_notations update_full_text_db kcdb_info classify_leader07a marc_info
 INSTALL_PROGS=$(filter-out %_test,$(PROGS))
 CGI_PROGS=full_text_lookup
 CCC=g++


### PR DESCRIPTION
… now

you have to call make with "make marc_grep_static" on Ubuntu in order to get
a entirely statically linked version of marc_grep.