### PR TITLE
Fixing bible range bug.

### DIFF
--- a/solr_plugins/Bibelstellensuche/src/de/uni_tuebingen/ub/ixTheo/bibleRangeSearch/Range.java
+++ b/solr_plugins/Bibelstellensuche/src/de/uni_tuebingen/ub/ixTheo/bibleRangeSearch/Range.java
@@ -41,8 +41,8 @@ class Range {
     }
 
     public float getMatchingScore(final Range other) {
-        final float numerator = Math.min(upper, other.upper) - Math.max(lower, other.lower);
-        final float denominator = Math.max(upper, other.upper) - Math.min(lower, other.lower);
+        final float numerator = Math.min(upper, other.upper) - Math.max(lower, other.lower) + 1;
+        final float denominator = Math.max(upper, other.upper) - Math.min(lower, other.lower) + 1;
         return numerator / denominator;
     }
 

--- a/solr_plugins/Bibelstellensuche/tests/de/uni_tuebingen/ub/ixTheo/bibleRangeSearch/ScoreTest.java
+++ b/solr_plugins/Bibelstellensuche/tests/de/uni_tuebingen/ub/ixTheo/bibleRangeSearch/ScoreTest.java
@@ -60,6 +60,28 @@ public class ScoreTest {
         assertRanking(expectedRanking, ranges);
     }
 
+
+    @Test
+    public void testPsalm_22_2() {
+        final BibleRange[] queryRanges = BibleRange.getRanges(new String[]{"6802202_6802202"});
+
+        BibleRange[] r0 = BibleRange.getRanges(new String[]{"6800100_6805099"});
+        BibleRange[] r1 = BibleRange.getRanges(new String[]{"6802200_6802299"});
+        BibleRange[] r2 = BibleRange.getRanges(new String[]{"6800100_6804199"});
+        BibleRange[] r3 = BibleRange.getRanges(new String[]{"6800100_6807299"});
+
+        HashMap<BibleRange[], Integer> expectedRanking = new HashMap<>();
+        expectedRanking.put(r0, 2);
+        expectedRanking.put(r1, 0);
+        expectedRanking.put(r2, 1);
+        expectedRanking.put(r3, 3);
+
+        BibleRange[][] ranges = new BibleRange[][]{r0, r1, r2, r3};
+        printScoring(ranges, queryRanges);
+        sortBySoring(ranges, queryRanges);
+        assertRanking(expectedRanking, ranges);
+    }
+
     /**
      * Prints the scoring for each list of bible ranges of fieldRanges.
      *


### PR DESCRIPTION
The algorithm is:
( Min(a.upper, b.upper) - Max(a.lower, b.lower)  ) / ( Max(a.upper, b.upper) - Min(a.lower, b.lower) )
Let's say the range [lower, upper] a = [2, 2] and b = [1, 5].
=> ( Min(2, 5) - Max(2, 1)  ) / ( Max(2, 5) - Min(2, 1) )
=> ( 2 - 2  ) / ( 5 - 1)
=> 0
So a bible range should have a thickness.