### PR TITLE
We use a dollar-sign as a separator and therefore it is risky to allo…

### DIFF
--- a/solrmarc_mixin/src/de/unituebingen/ub/ubtools/solrmarcMixin/TuelibMixin.java
+++ b/solrmarc_mixin/src/de/unituebingen/ub/ubtools/solrmarcMixin/TuelibMixin.java
@@ -995,7 +995,7 @@ public class TuelibMixin extends SolrIndexerMixin {
                 continue;
 
             final StringBuilder author2AndRoles = new StringBuilder();
-            author2AndRoles.append(author2);
+            author2AndRoles.append(author2.replace("$", ""));
             for (final Subfield _4Subfield : _4Subfields) {
                 author2AndRoles.append('$');
                 author2AndRoles.append(cleanRole(_4Subfield.getData()));


### PR DESCRIPTION
…w it as part of an author's name.