### PR TITLE
removed obsolete PHP dependencies

### DIFF
--- a/cpp/data/installer/scripts/install_centos_packages.sh
+++ b/cpp/data/installer/scripts/install_centos_packages.sh
@@ -50,7 +50,7 @@ if [[ $1 == "tuefind" ]]; then
         ColorEcho "replacing standard PHP with PHP 7.1"
         rpm -Uvh https://mirror.webtatic.com/yum/el7/webtatic-release.rpm
         yum --assumeyes remove 'php-*'
-        yum --assumeyes install php71w-cli php71w-common php71w-devel php71w-gd php71w-intl php71w-ldap php71w-mbstring php71w-mcrypt php71w-mysqlnd php71w-xml mod_php71w
+        yum --assumeyes install php71w-cli php71w-common php71w-gd php71w-intl php71w-ldap php71w-mbstring php71w-mysqlnd php71w-xml mod_php71w
         systemctl restart httpd
     fi
 

--- a/cpp/data/installer/scripts/install_ubuntu_packages.sh
+++ b/cpp/data/installer/scripts/install_ubuntu_packages.sh
@@ -45,7 +45,7 @@ if [[ $1 == "tuefind" ]]; then
     apt-get --quiet --yes install \
         composer openjdk-8-jdk \
         apache2 mysql-server \
-        php7.1 php7.1-curl php7.1-dev php7.1-gd php7.1-intl php7.1-json php7.1-ldap php7.1-mbstring php7.1-mcrypt php7.1-mysql php7.1-xsl php-pear \
+        php7.1 php7.1-curl php7.1-gd php7.1-intl php7.1-json php7.1-ldap php7.1-mbstring php7.1-mysql php7.1-xsl php-pear \
         libapache2-mod-gnutls libapache2-mod-php7.1
 
     # create /var/run/mysqld and change user (mysql installation right now has a bug not doing that itself)

--- a/cpp/data/installer/scripts/install_ubuntu_packages.sh
+++ b/cpp/data/installer/scripts/install_ubuntu_packages.sh
@@ -22,10 +22,6 @@ apt-get --yes update
 # install software-properties-common for apt-add-repository
 apt-get --yes install software-properties-common
 
-# needed for PHP-7.1
-apt-add-repository --yes ppa:ondrej/php
-apt-get --yes update
-
 # main installation
 # (use "quiet" so mysql hopefully doesnt ask for a root password, geographic area and timezone)
 apt-get --quiet --yes --allow-unauthenticated install \
@@ -45,8 +41,8 @@ if [[ $1 == "tuefind" ]]; then
     apt-get --quiet --yes install \
         composer openjdk-8-jdk \
         apache2 mysql-server \
-        php7.1 php7.1-curl php7.1-gd php7.1-intl php7.1-json php7.1-ldap php7.1-mbstring php7.1-mysql php7.1-xsl php-pear \
-        libapache2-mod-gnutls libapache2-mod-php7.1
+        php php-curl php-gd php-intl php-json php-ldap php-mbstring php-mysql php-xsl php-pear \
+        libapache2-mod-gnutls libapache2-mod-php
 
     # create /var/run/mysqld and change user (mysql installation right now has a bug not doing that itself)
     # (chown needs to be done after installation = after the user has been created)

--- a/cpp/data/installer/scripts/install_ubuntu_packages.sh
+++ b/cpp/data/installer/scripts/install_ubuntu_packages.sh
@@ -56,7 +56,6 @@ if [[ $1 == "tuefind" ]]; then
     chown -R mysql:mysql /var/run/mysqld
 
     a2enmod rewrite
-    phpenmod mcrypt
     /etc/init.d/apache2 restart
 fi
 


### PR DESCRIPTION
- mcrypt no longer needed since Vufind4 (and module will no longer be available in PHP7.2)
- dev not needed, because we don't develop PHP modules (package takes > 200MB!)