### PR TITLE
optional strptime_format for Zotero

### DIFF
--- a/cpp/data/zotero_cgi/index.html
+++ b/cpp/data/zotero_cgi/index.html
@@ -19,21 +19,23 @@
         {scripts_js}
 
         var rss_options_map = {{
-            {LOOP rss_journal_titles, rss_journal_issns, rss_feed_urls}
+            {LOOP rss_journal_titles, rss_journal_issns, rss_feed_urls, rss_strptime_formats}
                 "{rss_journal_titles}": {{
                     "issn": "{rss_journal_issns}",
                     "feed_url": "{rss_feed_urls}",
+                    "strptime_format": "{rss_strptime_formats}",
                 },
             {ENDLOOP}
         };
 
         var crawling_options_map = {{
-            {LOOP crawling_journal_titles, crawling_journal_issns, crawling_base_urls, crawling_extraction_regexes, crawling_depths}
+            {LOOP crawling_journal_titles, crawling_journal_issns, crawling_base_urls, crawling_extraction_regexes, crawling_depths, crawling_strptime_formats}
                 "{crawling_journal_titles}": {{
                     "issn": "{crawling_journal_issns}",
                     "base_url": "{crawling_base_urls}",
                     "regex": "{crawling_extraction_regexes}",
                     "depth": "{crawling_depths}",
+                    "strptime_format": "{crawling_strptime_formats}",
                 },
             {ENDLOOP}
         };
@@ -120,6 +122,7 @@
                 <tr><td colspan="3">Please note: This process can run for multiple minutes!</td></tr>
                 <tr><td colspan="3"><input type="submit"></input></td></tr>
             </table>
+            <input type="hidden" id="rss_strptime_format" name="rss_strptime_format" value="" />
             <input type="hidden" name="action" value="rss" />
         </form>
     </div>
@@ -173,6 +176,7 @@
                 <tr><td colspan="3">Please note: This process can run for multiple minutes!</td></tr>
                 <tr><td colspan="3"><input type="submit"></input></td></tr>
             </table>
+            <input type="hidden" id="crawling_strptime_format" name="crawling_strptime_format" value="" />
             <input type="hidden" name="action" value="crawling" />
         </form>
     </div>

--- a/cpp/data/zotero_cgi/scripts.js
+++ b/cpp/data/zotero_cgi/scripts.js
@@ -27,6 +27,7 @@ function OnChangeRssJournal() {
     var journal_options = rss_options_map[journal_title];
     $("#rss_journal_issn").val(journal_options.issn);
     $("#rss_feed_url").val(journal_options.feed_url);
+    $("#rss_strptime_format").val(journal_options.strptime_format);
 }
 
 function OnChangeCrawlingJournal() {
@@ -36,6 +37,7 @@ function OnChangeCrawlingJournal() {
     $("#crawling_base_url").val(journal_options.base_url);
     $("#crawling_extraction_regex").val(journal_options.regex);
     $("#crawling_depth").val(journal_options.depth);
+    $("#crawling_strptime_format").val(journal_options.strptime_format);
 }
 
 function TryRss(rss_journal_title) {

--- a/cpp/data/zts_harvester.conf
+++ b/cpp/data/zts_harvester.conf
@@ -84,6 +84,7 @@ issn             = "0003-2980"
 base_url         = "https://digitalcommons.andrews.edu/auss/"
 extraction_regex = ".*/iss[0-9]+/.*"
 max_crawl_depth  = 1
+strptime_format  = "%Y-%m-%d"
 
 # Kim example CRAWL 4 - a lot of PDFs?
 [KimCRAWL4 - Estudios Eclesiàsticos]

--- a/cpp/data/zts_harvester.conf
+++ b/cpp/data/zts_harvester.conf
@@ -93,6 +93,7 @@ issn             = "0210-1610"
 base_url         = "http://revistas.upcomillas.es/index.php/estudioseclesiasticos/issue/archive"
 extraction_regex = ".*/(issue|article)/.*"
 max_crawl_depth  = 2
+strptime_format  = "%Y/%m/%d"
 
 # Kim example CRAWL 5
 [KimCRAWL5 - Archives de sciences sociales des religions]

--- a/cpp/lib/include/SimpleCrawler.h
+++ b/cpp/lib/include/SimpleCrawler.h
@@ -79,10 +79,11 @@ public:
     struct SiteDesc {
         std::string start_url_;
         unsigned max_crawl_depth_;
+        std::string strptime_format_; // an optional format as understood by strptime(3)
         std::shared_ptr<RegexMatcher> url_regex_matcher_; // all non-matching URL's of subpages will be ignored
     public:
-        SiteDesc(const std::string &start_url, const unsigned max_crawl_depth, RegexMatcher * const url_regex_matcher)
-            : start_url_(start_url), max_crawl_depth_(max_crawl_depth), url_regex_matcher_(url_regex_matcher) { }
+        SiteDesc(const std::string &start_url, const unsigned max_crawl_depth, const std::string &strptime_format, RegexMatcher * const url_regex_matcher)
+            : start_url_(start_url), max_crawl_depth_(max_crawl_depth), strptime_format_(strptime_format), url_regex_matcher_(url_regex_matcher) { }
         ~SiteDesc() = default;
     };
 

--- a/cpp/lib/include/Zotero.h
+++ b/cpp/lib/include/Zotero.h
@@ -107,7 +107,7 @@ public:
  *  \param  harvest_maps    The map files to apply.
  */
 void AugmentJson(const std::shared_ptr<JSON::ObjectNode> &object_node,
-                 AugmentParams &augment_params);
+                 AugmentParams * const augment_params);
 
 
 // forward declaration
@@ -126,11 +126,11 @@ class FormatHandler {
 protected:
     std::string output_format_;
     std::string output_file_;
-    AugmentParams &augment_params_;
+    AugmentParams * const augment_params_;
     const std::shared_ptr<const HarvestParams> &harvest_params_;
 
     FormatHandler(const std::string &output_format, const std::string &output_file,
-                  AugmentParams &augment_params, const std::shared_ptr<const HarvestParams> &harvest_params)
+                  AugmentParams * const augment_params, const std::shared_ptr<const HarvestParams> &harvest_params)
         : output_format_(output_format), output_file_(output_file), augment_params_(augment_params), harvest_params_(harvest_params)
         { }
 public:
@@ -142,7 +142,7 @@ public:
     // The output format must be one of "bibtex", "biblatex", "bookmarks", "coins", "csljson", "mods", "refer",
     // "rdf_bibliontology", "rdf_dc", "rdf_zotero", "ris", "wikipedia", "tei", "json", "marc21", or "marcxml".
     static std::unique_ptr<FormatHandler> Factory(const std::string &output_format, const std::string &output_file,
-                                                  AugmentParams &augment_params,
+                                                  AugmentParams * const augment_params,
                                                   const std::shared_ptr<const HarvestParams> &harvest_params);
 };
 
@@ -152,7 +152,7 @@ class JsonFormatHandler final : public FormatHandler {
     File *output_file_object_;
 public:
     JsonFormatHandler(const std::string &output_format, const std::string &output_file,
-                      AugmentParams &augment_params, const std::shared_ptr<const HarvestParams> &harvest_params);
+                      AugmentParams * const augment_params, const std::shared_ptr<const HarvestParams> &harvest_params);
     virtual ~JsonFormatHandler();
     virtual std::pair<unsigned, unsigned> processRecord(const std::shared_ptr<const JSON::ObjectNode> &object_node) override;
 };
@@ -163,7 +163,7 @@ class ZoteroFormatHandler final : public FormatHandler {
     std::string json_buffer_;
 public:
     ZoteroFormatHandler(const std::string &output_format, const std::string &output_file,
-                        AugmentParams &augment_params, const std::shared_ptr<const HarvestParams> &harvest_params);
+                        AugmentParams * const augment_params, const std::shared_ptr<const HarvestParams> &harvest_params);
     virtual ~ZoteroFormatHandler();
     virtual std::pair<unsigned, unsigned> processRecord(const std::shared_ptr<const JSON::ObjectNode> &object_node) override;
 };
@@ -172,7 +172,7 @@ public:
 class MarcFormatHandler final : public FormatHandler {
     std::unique_ptr<MARC::Writer> marc_writer_;
 public:
-    MarcFormatHandler(const std::string &output_file, AugmentParams &augment_params,
+    MarcFormatHandler(const std::string &output_file, AugmentParams * const augment_params,
                       const std::shared_ptr<const HarvestParams> &harvest_params);
     virtual ~MarcFormatHandler() = default;
     virtual std::pair<unsigned, unsigned> processRecord(const std::shared_ptr<const JSON::ObjectNode> &object_node) override;
@@ -227,7 +227,7 @@ AugmentMaps LoadMapFilesFromDirectory(const std::string &map_directory_path);
  *          difference (first - second).
  */
 std::pair<unsigned, unsigned> Harvest(const std::string &harvest_url, const std::shared_ptr<HarvestParams> harvest_params,
-                                      AugmentParams &augment_params,
+                                      AugmentParams * const augment_params,
                                       const std::string &harvested_html = "", const bool log = true);
 
 
@@ -323,7 +323,7 @@ public:
 UnsignedPair HarvestSite(const SimpleCrawler::SiteDesc &site_desc, const SimpleCrawler::Params &crawler_params,
                          const std::shared_ptr<RegexMatcher> &supported_urls_regex,
                          const std::shared_ptr<HarvestParams> &harvest_params,
-                         AugmentParams &augment_params,
+                         AugmentParams * const augment_params,
                          File * const progress_file = nullptr);
 
 

--- a/cpp/lib/include/Zotero.h
+++ b/cpp/lib/include/Zotero.h
@@ -89,16 +89,17 @@ struct AugmentMaps {
     std::unordered_map<std::string, std::string> ISSN_to_volume_map_;
     std::unordered_map<std::string, std::string> language_to_language_code_map_;
     std::unordered_set<std::string> previously_downloaded_;
+
+    AugmentMaps(const std::string &map_directory_path);
 };
 
 
-class AugmentParams {
-public:
+struct AugmentParams {
     std::string override_ISSN_;
     std::string strptime_format_;
-    AugmentMaps maps_;
-public:
-    ~AugmentParams() = default;
+    AugmentMaps * const maps_;
+
+    AugmentParams(AugmentMaps * const maps): maps_(maps) { }
 };
 
 
@@ -209,8 +210,6 @@ private:
 
 
 const std::shared_ptr<RegexMatcher> LoadSupportedURLsRegex(const std::string &map_directory_path);
-
-AugmentMaps LoadMapFilesFromDirectory(const std::string &map_directory_path);
 
 
 /** \brief  Harvest a single URL.

--- a/cpp/lib/src/MARC.cc
+++ b/cpp/lib/src/MARC.cc
@@ -617,7 +617,7 @@ FileType GuessFileType(const std::string &filename) {
         or StringUtil::EndsWith(filename, ".raw", /* ignore_case = */true))
         return FileType::BINARY;
     if (StringUtil::EndsWith(filename, ".xml", /* ignore_case = */true))
-        return FileType::BINARY;
+        return FileType::XML;
 
     LOG_ERROR("can't guess the file type of \"" + filename + "\"!");
 }

--- a/cpp/lib/src/SimpleCrawler.cc
+++ b/cpp/lib/src/SimpleCrawler.cc
@@ -65,7 +65,8 @@ void SimpleCrawler::ParseConfigFile(const std::string &config_path, std::vector<
             continue;
 
         std::vector<std::string> line_parts;
-        if (StringUtil::SplitThenTrimWhite(line, ' ', &line_parts) != 3)
+        const unsigned no_of_parts(StringUtil::SplitThenTrimWhite(line, ' ', &line_parts));
+        if (no_of_parts != 3 and no_of_parts != 4)
             LOG_ERROR("bad input line #" + std::to_string(line_no) + " in \""
                    + input->getPath() + "\"!");
 
@@ -79,7 +80,12 @@ void SimpleCrawler::ParseConfigFile(const std::string &config_path, std::vector<
         if (url_regex_matcher == nullptr)
             LOG_ERROR("bad input line #" + std::to_string(line_no) + " in \""
                    + input->getPath() + "\", regex is faulty! (" + err_msg + ")");
-        site_descs->emplace_back(line_parts[0], max_crawl_depth, url_regex_matcher);
+
+        std::string strptime_format;
+        if (no_of_parts == 4)
+            strptime_format = line_parts[3];
+
+        site_descs->emplace_back(line_parts[0], max_crawl_depth, strptime_format, url_regex_matcher);
     }
 }
 

--- a/cpp/lib/src/Zotero.cc
+++ b/cpp/lib/src/Zotero.cc
@@ -189,23 +189,23 @@ bool Web(const Url &zts_server_url, const TimeLimit &time_limit, Downloader::Par
 
 std::unique_ptr<FormatHandler> FormatHandler::Factory(const std::string &output_format,
                                                       const std::string &output_file,
-                                                      const std::shared_ptr<HarvestMaps> &harvest_maps,
-                                                      const std::shared_ptr<HarvestParams> &harvest_params)
+                                                      AugmentParams &augment_params,
+                                                      const std::shared_ptr<const HarvestParams> &harvest_params)
 {
     if (output_format == "marcxml" or output_format == "marc21")
-        return std::unique_ptr<FormatHandler>(new MarcFormatHandler(output_file, harvest_maps, harvest_params));
+        return std::unique_ptr<FormatHandler>(new MarcFormatHandler(output_file, augment_params, harvest_params));
     else if (output_format == "json")
-        return std::unique_ptr<FormatHandler>(new JsonFormatHandler(output_format, output_file, harvest_maps, harvest_params));
+        return std::unique_ptr<FormatHandler>(new JsonFormatHandler(output_format, output_file, augment_params, harvest_params));
     else if (std::find(EXPORT_FORMATS.begin(), EXPORT_FORMATS.end(), output_format) != EXPORT_FORMATS.end())
-        return std::unique_ptr<FormatHandler>(new ZoteroFormatHandler(output_format, output_file, harvest_maps, harvest_params));
+        return std::unique_ptr<FormatHandler>(new ZoteroFormatHandler(output_format, output_file, augment_params, harvest_params));
     else
         LOG_ERROR("invalid output-format: " + output_format);
 }
 
 
 JsonFormatHandler::JsonFormatHandler(const std::string &output_format, const std::string &output_file,
-                                     const std::shared_ptr<HarvestMaps> &harvest_maps, const std::shared_ptr<HarvestParams> &harvest_params)
-    : FormatHandler(output_format, output_file, harvest_maps, harvest_params), record_count_(0),
+                                     AugmentParams &augment_params, const std::shared_ptr<const HarvestParams> &harvest_params)
+    : FormatHandler(output_format, output_file, augment_params, harvest_params), record_count_(0),
       output_file_object_(new File(output_file_, "w"))
 {
     output_file_object_->write("[");
@@ -228,8 +228,8 @@ std::pair<unsigned, unsigned> JsonFormatHandler::processRecord(const std::shared
 
 
 ZoteroFormatHandler::ZoteroFormatHandler(const std::string &output_format, const std::string &output_file,
-                                         const std::shared_ptr<HarvestMaps> &harvest_maps, const std::shared_ptr<HarvestParams> &harvest_params)
-    : FormatHandler(output_format, output_file, harvest_maps, harvest_params), record_count_(0), json_buffer_("[")
+                                         AugmentParams &augment_params, const std::shared_ptr<const HarvestParams> &harvest_params)
+    : FormatHandler(output_format, output_file, augment_params, harvest_params), record_count_(0), json_buffer_("[")
 {
 }
 
@@ -270,8 +270,8 @@ std::string GuessOutputFormat(const std::string &output_file) {
 
 
 MarcFormatHandler::MarcFormatHandler(const std::string &output_file,
-                                     const std::shared_ptr<HarvestMaps> &harvest_maps, const std::shared_ptr<HarvestParams> &harvest_params)
-    : FormatHandler(GuessOutputFormat(output_file), output_file, harvest_maps, harvest_params),
+                                     AugmentParams &augment_params, const std::shared_ptr<const HarvestParams> &harvest_params)
+    : FormatHandler(GuessOutputFormat(output_file), output_file, augment_params, harvest_params),
       marc_writer_(MARC::Writer::Factory(output_file_))
 {
 }
@@ -508,7 +508,7 @@ std::pair<unsigned, unsigned> MarcFormatHandler::processRecord(const std::shared
     // keywords:
     const std::shared_ptr<const JSON::JSONNode>tags_node(object_node->getNode("tags"));
     if (tags_node != nullptr)
-        ExtractKeywords(tags_node, issn_normalized, harvest_maps_->ISSN_to_keyword_field_map_, &new_record);
+        ExtractKeywords(tags_node, issn_normalized, augment_params_.maps_.ISSN_to_keyword_field_map_, &new_record);
 
     // Populate 773:
     if (is_journal_article) {
@@ -529,8 +529,8 @@ std::pair<unsigned, unsigned> MarcFormatHandler::processRecord(const std::shared
 
     // previously downloaded?
     const std::string checksum(MARC::CalcChecksum(new_record, /* exclude_001 = */ true));
-    if (harvest_maps_->previously_downloaded_.find(checksum) == harvest_maps_->previously_downloaded_.cend()) {
-        harvest_maps_->previously_downloaded_.emplace(checksum);
+    if (augment_params_.maps_.previously_downloaded_.find(checksum) == augment_params_.maps_.previously_downloaded_.cend()) {
+        augment_params_.maps_.previously_downloaded_.emplace(checksum);
         marc_writer_->write(new_record);
     } else
         ++previously_downloaded_count;
@@ -591,9 +591,8 @@ void AugmentJsonCreators(const std::shared_ptr<JSON::ArrayNode> creators_array,
 
 
 // Improve JSON result delivered by Zotero Translation Server
-void AugmentJson(const std::shared_ptr<JSON::ObjectNode> object_node,
-                 const AugmentParams &augment_params,
-                 const std::shared_ptr<const HarvestMaps> harvest_maps)
+void AugmentJson(const std::shared_ptr<JSON::ObjectNode> &object_node,
+                 AugmentParams &augment_params)
 {
     LOG_INFO("Augmenting JSON...");
     std::map<std::string, std::string> custom_fields;
@@ -605,7 +604,7 @@ void AugmentJson(const std::shared_ptr<JSON::ObjectNode> object_node,
             language_node = JSON::JSONNode::CastToStringNodeOrDie("language", key_and_node.second);
             const std::string language_json(language_node->getValue());
             const std::string language_mapped(OptionalMap(language_json,
-                            harvest_maps->language_to_language_code_map_));
+                            augment_params.maps_.language_to_language_code_map_));
             if (language_json != language_mapped) {
                 language_node->setValue(language_mapped);
                 comments.emplace_back("changed \"language\" from \"" + language_json + "\" to \"" + language_mapped + "\"");
@@ -622,8 +621,8 @@ void AugmentJson(const std::shared_ptr<JSON::ObjectNode> object_node,
             custom_fields.emplace(std::pair<std::string, std::string>("ISSN_raw", issn_raw));
             custom_fields.emplace(std::pair<std::string, std::string>("ISSN_normalized", issn_normalized));
 
-            const auto ISSN_and_parent_ppn(harvest_maps->ISSN_to_superior_ppn_map_.find(issn_normalized));
-            if (ISSN_and_parent_ppn != harvest_maps->ISSN_to_superior_ppn_map_.cend())
+            const auto ISSN_and_parent_ppn(augment_params.maps_.ISSN_to_superior_ppn_map_.find(issn_normalized));
+            if (ISSN_and_parent_ppn != augment_params.maps_.ISSN_to_superior_ppn_map_.cend())
                 custom_fields.emplace(std::pair<std::string, std::string>("PPN", ISSN_and_parent_ppn->second));
         } else if (key_and_node.first == "date") {
             const std::string date_raw(JSON::JSONNode::CastToStringNodeOrDie(key_and_node.first, key_and_node.second)->getValue());
@@ -638,8 +637,8 @@ void AugmentJson(const std::shared_ptr<JSON::ObjectNode> object_node,
     // ISSN specific overrides
     if (not issn_normalized.empty()) {
         // physical form
-        const auto ISSN_and_physical_form(harvest_maps->ISSN_to_physical_form_map_.find(issn_normalized));
-        if (ISSN_and_physical_form != harvest_maps->ISSN_to_physical_form_map_.cend()) {
+        const auto ISSN_and_physical_form(augment_params.maps_.ISSN_to_physical_form_map_.find(issn_normalized));
+        if (ISSN_and_physical_form != augment_params.maps_.ISSN_to_physical_form_map_.cend()) {
             if (ISSN_and_physical_form->second == "A")
                 custom_fields.emplace(std::pair<std::string, std::string>("physicalForm", "A"));
             else if (ISSN_and_physical_form->second == "O")
@@ -649,8 +648,8 @@ void AugmentJson(const std::shared_ptr<JSON::ObjectNode> object_node,
         }
 
         // language
-        const auto ISSN_and_language(harvest_maps->ISSN_to_language_code_map_.find(issn_normalized));
-        if (ISSN_and_language != harvest_maps->ISSN_to_language_code_map_.cend()) {
+        const auto ISSN_and_language(augment_params.maps_.ISSN_to_language_code_map_.find(issn_normalized));
+        if (ISSN_and_language != augment_params.maps_.ISSN_to_language_code_map_.cend()) {
             if (language_node != nullptr) {
                 const std::string language_old(language_node->getValue());
                 language_node->setValue(ISSN_and_language->second);
@@ -666,8 +665,8 @@ void AugmentJson(const std::shared_ptr<JSON::ObjectNode> object_node,
         // volume
         const std::string volume(object_node->getOptionalStringValue("volume"));
         if (volume.empty()) {
-            const auto ISSN_and_volume(harvest_maps->ISSN_to_volume_map_.find(issn_normalized));
-            if (ISSN_and_volume != harvest_maps->ISSN_to_volume_map_.cend()) {
+            const auto ISSN_and_volume(augment_params.maps_.ISSN_to_volume_map_.find(issn_normalized));
+            if (ISSN_and_volume != augment_params.maps_.ISSN_to_volume_map_.cend()) {
                 if (volume.empty()) {
                     const std::shared_ptr<JSON::JSONNode> volume_node(object_node->getNode("volume"));
                     JSON::JSONNode::CastToStringNodeOrDie("volume", volume_node)->setValue(ISSN_and_volume->second);
@@ -679,8 +678,8 @@ void AugmentJson(const std::shared_ptr<JSON::ObjectNode> object_node,
         }
 
         // license code
-        const auto ISSN_and_license_code(harvest_maps->ISSN_to_licence_map_.find(issn_normalized));
-        if (ISSN_and_license_code != harvest_maps->ISSN_to_licence_map_.end()) {
+        const auto ISSN_and_license_code(augment_params.maps_.ISSN_to_licence_map_.find(issn_normalized));
+        if (ISSN_and_license_code != augment_params.maps_.ISSN_to_licence_map_.end()) {
             if (ISSN_and_license_code->second != "l")
                 LOG_ERROR("ISSN_to_licence.map contains an ISSN that has not been mapped to an \"l\" but \""
                           + ISSN_and_license_code->second
@@ -690,8 +689,8 @@ void AugmentJson(const std::shared_ptr<JSON::ObjectNode> object_node,
         }
 
         // SSG numbers:
-        const auto ISSN_and_SSGN_numbers(harvest_maps->ISSN_to_SSG_map_.find(issn_normalized));
-        if (ISSN_and_SSGN_numbers != harvest_maps->ISSN_to_SSG_map_.end())
+        const auto ISSN_and_SSGN_numbers(augment_params.maps_.ISSN_to_SSG_map_.find(issn_normalized));
+        if (ISSN_and_SSGN_numbers != augment_params.maps_.ISSN_to_SSG_map_.end())
             custom_fields.emplace(std::pair<std::string, std::string>("ssgNumbers", ISSN_and_SSGN_numbers->second));
     }
 
@@ -740,22 +739,22 @@ const std::shared_ptr<RegexMatcher> LoadSupportedURLsRegex(const std::string &ma
 }
 
 
-std::shared_ptr<HarvestMaps> LoadMapFilesFromDirectory(const std::string &map_directory_path) {
-    std::shared_ptr<HarvestMaps> maps(new HarvestMaps);
-    MiscUtil::LoadMapFile(map_directory_path + "language_to_language_code.map", &maps->language_to_language_code_map_);
-    MiscUtil::LoadMapFile(map_directory_path + "ISSN_to_language_code.map", &maps->ISSN_to_language_code_map_);
-    MiscUtil::LoadMapFile(map_directory_path + "ISSN_to_licence.map", &maps->ISSN_to_licence_map_);
-    MiscUtil::LoadMapFile(map_directory_path + "ISSN_to_keyword_field.map", &maps->ISSN_to_keyword_field_map_);
-    MiscUtil::LoadMapFile(map_directory_path + "ISSN_to_physical_form.map", &maps->ISSN_to_physical_form_map_);
-    MiscUtil::LoadMapFile(map_directory_path + "ISSN_to_superior_ppn.map", &maps->ISSN_to_superior_ppn_map_);
-    MiscUtil::LoadMapFile(map_directory_path + "ISSN_to_volume.map", &maps->ISSN_to_volume_map_);
-    MiscUtil::LoadMapFile(map_directory_path + "ISSN_to_SSG.map", &maps->ISSN_to_SSG_map_);
+AugmentMaps LoadMapFilesFromDirectory(const std::string &map_directory_path) {
+    AugmentMaps maps;
+    MiscUtil::LoadMapFile(map_directory_path + "language_to_language_code.map", &maps.language_to_language_code_map_);
+    MiscUtil::LoadMapFile(map_directory_path + "ISSN_to_language_code.map", &maps.ISSN_to_language_code_map_);
+    MiscUtil::LoadMapFile(map_directory_path + "ISSN_to_licence.map", &maps.ISSN_to_licence_map_);
+    MiscUtil::LoadMapFile(map_directory_path + "ISSN_to_keyword_field.map", &maps.ISSN_to_keyword_field_map_);
+    MiscUtil::LoadMapFile(map_directory_path + "ISSN_to_physical_form.map", &maps.ISSN_to_physical_form_map_);
+    MiscUtil::LoadMapFile(map_directory_path + "ISSN_to_superior_ppn.map", &maps.ISSN_to_superior_ppn_map_);
+    MiscUtil::LoadMapFile(map_directory_path + "ISSN_to_volume.map", &maps.ISSN_to_volume_map_);
+    MiscUtil::LoadMapFile(map_directory_path + "ISSN_to_SSG.map", &maps.ISSN_to_SSG_map_);
     return maps;
 }
 
 
 std::pair<unsigned, unsigned> Harvest(const std::string &harvest_url, const std::shared_ptr<HarvestParams> harvest_params,
-                                      const std::shared_ptr<const HarvestMaps> harvest_maps, const AugmentParams &augment_params,
+                                      AugmentParams &augment_params,
                                       const std::string &harvested_html, bool log)
 {
     std::pair<unsigned, unsigned> record_count_and_previously_downloaded_count;
@@ -807,7 +806,7 @@ std::pair<unsigned, unsigned> Harvest(const std::string &harvest_url, const std:
                                                                                                            tree_root));
             for (const auto &key_and_node : *object_node) {
                 std::pair<unsigned, unsigned> record_count_and_previously_downloaded_count2 =
-                    Harvest(key_and_node.first, harvest_params, harvest_maps, augment_params, /* harvested_html = */"", /* log = */false);
+                    Harvest(key_and_node.first, harvest_params, augment_params, /* harvested_html = */"", /* log = */false);
 
                 record_count_and_previously_downloaded_count.first += record_count_and_previously_downloaded_count2.first;
                 record_count_and_previously_downloaded_count.second += record_count_and_previously_downloaded_count2.second;
@@ -817,7 +816,7 @@ std::pair<unsigned, unsigned> Harvest(const std::string &harvest_url, const std:
         const std::shared_ptr<const JSON::ArrayNode>json_array(JSON::JSONNode::CastToArrayNodeOrDie("tree_root", tree_root));
         for (const auto entry : *json_array) {
             const std::shared_ptr<JSON::ObjectNode> json_object(JSON::JSONNode::CastToObjectNodeOrDie("entry", entry));
-            AugmentJson(json_object, augment_params, harvest_maps);
+            AugmentJson(json_object, augment_params);
             record_count_and_previously_downloaded_count = harvest_params->format_handler_->processRecord(json_object);
         }
     }
@@ -1033,8 +1032,8 @@ DownloadTracker::const_iterator DownloadTracker::end() const {
  */
 UnsignedPair HarvestSite(const SimpleCrawler::SiteDesc &site_desc, const SimpleCrawler::Params &crawler_params,
                          const std::shared_ptr<RegexMatcher> &supported_urls_regex,
-                         const std::shared_ptr<Zotero::HarvestParams> &harvest_params,
-                         const std::shared_ptr<const Zotero::HarvestMaps> &harvest_maps,
+                         const std::shared_ptr<HarvestParams> &harvest_params,
+                         AugmentParams &augment_params,
                          File * const progress_file)
 {
     UnsignedPair total_record_count_and_previously_downloaded_record_count;
@@ -1046,10 +1045,9 @@ UnsignedPair HarvestSite(const SimpleCrawler::SiteDesc &site_desc, const SimpleC
         if (not supported_urls_regex->matched(page_details.url_))
             LOG_INFO("Skipping unsupported URL: " + page_details.url_);
         else if (page_details.error_message_.empty()) {
-            Zotero::AugmentParams augment_params;
             augment_params.strptime_format_ = site_desc.strptime_format_;
             const auto record_count_and_previously_downloaded_count(
-                Zotero::Harvest(page_details.url_, harvest_params, harvest_maps, augment_params, page_details.body_));
+                Zotero::Harvest(page_details.url_, harvest_params, augment_params, page_details.body_));
             total_record_count_and_previously_downloaded_record_count.first  += record_count_and_previously_downloaded_count.first;
             total_record_count_and_previously_downloaded_record_count.second += record_count_and_previously_downloaded_count.second;
             if (progress_file != nullptr) {

--- a/cpp/rss_harvester.cc
+++ b/cpp/rss_harvester.cc
@@ -152,7 +152,7 @@ unsigned ProcessSyndicationURL(const Mode mode, const std::string &feed_url,
         if (last_build_date != TimeUtil::BAD_TIME_T)
             std::cout << "\tLast build date: " << TimeUtil::TimeTToUtcString(last_build_date) << '\n';
         std::cout << "\tLink: " << syndication_format->getLink() << '\n';
-        std::cout << "\tDescription: " << syndication_format->getDescription() << '\n'; 
+        std::cout << "\tDescription: " << syndication_format->getDescription() << '\n';
    }
 
     if (mode != TEST and FeedContainsNoNewItems(mode, db_connection, feed_url, last_build_date))
@@ -167,8 +167,9 @@ unsigned ProcessSyndicationURL(const Mode mode, const std::string &feed_url,
         if (not title.empty() and mode != NORMAL)
             std::cout << "\t\tTitle: " << title << '\n';
 
+        const Zotero::AugmentParams augment_params;
         const auto record_count_and_previously_downloaded_count(
-            Zotero::Harvest(item.getLink(), harvest_params, harvest_maps, "", /* verbose = */ mode != NORMAL));
+            Zotero::Harvest(item.getLink(), harvest_params, harvest_maps, augment_params, "", /* verbose = */ mode != NORMAL));
         successfully_processed_count += record_count_and_previously_downloaded_count.first;
 
         if (mode != TEST)
@@ -265,7 +266,7 @@ int main(int argc, char *argv[]) {
             const std::string sql_password(ini_file.getString("Database", "sql_password"));
             db_connection.reset(new DbConnection(sql_database, sql_username, sql_password));
         }
- 
+
         Zotero::MarcFormatHandler * const marc_format_handler(reinterpret_cast<Zotero::MarcFormatHandler *>(
             harvest_params->format_handler_.get()));
         if (unlikely(marc_format_handler == nullptr))

--- a/cpp/rss_harvester.cc
+++ b/cpp/rss_harvester.cc
@@ -125,7 +125,7 @@ bool ItemAlreadyProcessed(DbConnection * const db_connection, const std::string 
 
 unsigned ProcessSyndicationURL(const Mode mode, const std::string &feed_url,
                                const std::shared_ptr<Zotero::HarvestParams> harvest_params,
-                               Zotero::AugmentParams &augment_params, DbConnection * const db_connection)
+                               Zotero::AugmentParams * const augment_params, DbConnection * const db_connection)
 {
     unsigned successfully_processed_count(0);
 
@@ -256,7 +256,7 @@ int main(int argc, char *argv[]) {
                                                                                        &augment_params.maps_.previously_downloaded_);
         const std::string MARC_OUTPUT_FILE(argv[4]);
         harvest_params->format_handler_ = Zotero::FormatHandler::Factory(GetMarcFormat(MARC_OUTPUT_FILE), MARC_OUTPUT_FILE,
-                                                                         augment_params, harvest_params);
+                                                                         &augment_params, harvest_params);
 
         std::unique_ptr<DbConnection> db_connection;
         if (mode != TEST) {
@@ -274,7 +274,7 @@ int main(int argc, char *argv[]) {
 
         unsigned download_count(0);
         for (const auto &server_url : server_urls)
-            download_count += ProcessSyndicationURL(mode, server_url, harvest_params, augment_params, db_connection.get());
+            download_count += ProcessSyndicationURL(mode, server_url, harvest_params, &augment_params, db_connection.get());
 
         LOG_INFO("Extracted metadata from " + std::to_string(download_count) + " page(s).");
     } catch (const std::exception &x) {

--- a/cpp/rss_harvester.cc
+++ b/cpp/rss_harvester.cc
@@ -247,13 +247,9 @@ int main(int argc, char *argv[]) {
         if (not StringUtil::EndsWith(map_directory_path, '/'))
             map_directory_path += '/';
 
-        Zotero::AugmentParams augment_params;
-        augment_params.maps_ = Zotero::LoadMapFilesFromDirectory(map_directory_path);
+        Zotero::AugmentMaps augment_maps(map_directory_path);
+        Zotero::AugmentParams augment_params(&augment_maps);
         const std::shared_ptr<RegexMatcher> supported_urls_regex(Zotero::LoadSupportedURLsRegex(map_directory_path));
-
-        const std::string PREVIOUSLY_DOWNLOADED_HASHES_PATH(map_directory_path + "previously_downloaded.hashes");
-        Zotero::PreviouslyDownloadedHashesManager previously_downloaded_hashes_manager(PREVIOUSLY_DOWNLOADED_HASHES_PATH,
-                                                                                       &augment_params.maps_.previously_downloaded_);
         const std::string MARC_OUTPUT_FILE(argv[4]);
         harvest_params->format_handler_ = Zotero::FormatHandler::Factory(GetMarcFormat(MARC_OUTPUT_FILE), MARC_OUTPUT_FILE,
                                                                          &augment_params, harvest_params);

--- a/cpp/zts_client.cc
+++ b/cpp/zts_client.cc
@@ -61,13 +61,13 @@ void Usage() {
 void HarvestSites(const SimpleCrawler::Params &crawler_params, const std::shared_ptr<RegexMatcher> supported_urls_regex,
                   const std::vector<SimpleCrawler::SiteDesc> &site_descs,
                   const std::shared_ptr<Zotero::HarvestParams> harvest_params,
-                  const std::shared_ptr<const Zotero::HarvestMaps> harvest_maps, std::unique_ptr<File> &progress_file,
+                  Zotero::AugmentParams &augment_params, std::unique_ptr<File> &progress_file,
                   unsigned * const total_record_count, unsigned * const total_previously_downloaded_count)
 {
     UnsignedPair total_record_count_and_previously_downloaded_record_count;
     for (const auto &site_desc : site_descs)
         total_record_count_and_previously_downloaded_record_count
-            += Zotero::HarvestSite(site_desc, crawler_params, supported_urls_regex, harvest_params, harvest_maps, progress_file.get());
+            += Zotero::HarvestSite(site_desc, crawler_params, supported_urls_regex, harvest_params, augment_params, progress_file.get());
 
     logger->info("Processed " + std::to_string(total_record_count_and_previously_downloaded_record_count.first)
                  + " (new: "
@@ -130,15 +130,16 @@ void Main(int argc, char *argv[]) {
 
     try {
         harvest_params->zts_server_url_ = Url(argv[1]);
-        std::shared_ptr<Zotero::HarvestMaps> harvest_maps(Zotero::LoadMapFilesFromDirectory(map_directory_path));
+        Zotero::AugmentParams augment_params;
+        augment_params.maps_ = Zotero::LoadMapFilesFromDirectory(map_directory_path);
         const std::shared_ptr<RegexMatcher> supported_urls_regex(Zotero::LoadSupportedURLsRegex(map_directory_path));
 
         const std::string PREVIOUSLY_DOWNLOADED_HASHES_PATH(map_directory_path + "previously_downloaded.hashes");
         Zotero::PreviouslyDownloadedHashesManager previously_downloaded_hashes_manager(PREVIOUSLY_DOWNLOADED_HASHES_PATH,
-                                                                                       &harvest_maps->previously_downloaded_);
+                                                                                       &augment_params.maps_.previously_downloaded_);
 
         const std::string output_file(argv[3]);
-        harvest_params->format_handler_ = Zotero::FormatHandler::Factory(output_format, output_file, harvest_maps, harvest_params);
+        harvest_params->format_handler_ = Zotero::FormatHandler::Factory(output_format, output_file, augment_params, harvest_params);
         unsigned total_record_count(0), total_previously_downloaded_count(0);
 
         std::unique_ptr<File> progress_file;
@@ -155,7 +156,7 @@ void Main(int argc, char *argv[]) {
         SimpleCrawler::ParseConfigFile(simple_crawler_config_path, &site_descs);
 
         HarvestSites(crawler_params, supported_urls_regex, site_descs,
-                     harvest_params, harvest_maps, progress_file,
+                     harvest_params, augment_params, progress_file,
                      &total_record_count, &total_previously_downloaded_count);
 
         LOG_INFO("Harvested a total of " + StringUtil::ToString(total_record_count) + " records of which "

--- a/cpp/zts_client.cc
+++ b/cpp/zts_client.cc
@@ -130,13 +130,9 @@ void Main(int argc, char *argv[]) {
 
     try {
         harvest_params->zts_server_url_ = Url(argv[1]);
-        Zotero::AugmentParams augment_params;
-        augment_params.maps_ = Zotero::LoadMapFilesFromDirectory(map_directory_path);
+        Zotero::AugmentMaps augment_maps(map_directory_path);
+        Zotero::AugmentParams augment_params(&augment_maps);
         const std::shared_ptr<RegexMatcher> supported_urls_regex(Zotero::LoadSupportedURLsRegex(map_directory_path));
-
-        const std::string PREVIOUSLY_DOWNLOADED_HASHES_PATH(map_directory_path + "previously_downloaded.hashes");
-        Zotero::PreviouslyDownloadedHashesManager previously_downloaded_hashes_manager(PREVIOUSLY_DOWNLOADED_HASHES_PATH,
-                                                                                       &augment_params.maps_.previously_downloaded_);
 
         const std::string output_file(argv[3]);
         harvest_params->format_handler_ = Zotero::FormatHandler::Factory(output_format, output_file, &augment_params, harvest_params);

--- a/cpp/zts_client.cc
+++ b/cpp/zts_client.cc
@@ -61,7 +61,7 @@ void Usage() {
 void HarvestSites(const SimpleCrawler::Params &crawler_params, const std::shared_ptr<RegexMatcher> supported_urls_regex,
                   const std::vector<SimpleCrawler::SiteDesc> &site_descs,
                   const std::shared_ptr<Zotero::HarvestParams> harvest_params,
-                  Zotero::AugmentParams &augment_params, std::unique_ptr<File> &progress_file,
+                  Zotero::AugmentParams * const augment_params, std::unique_ptr<File> &progress_file,
                   unsigned * const total_record_count, unsigned * const total_previously_downloaded_count)
 {
     UnsignedPair total_record_count_and_previously_downloaded_record_count;
@@ -139,7 +139,7 @@ void Main(int argc, char *argv[]) {
                                                                                        &augment_params.maps_.previously_downloaded_);
 
         const std::string output_file(argv[3]);
-        harvest_params->format_handler_ = Zotero::FormatHandler::Factory(output_format, output_file, augment_params, harvest_params);
+        harvest_params->format_handler_ = Zotero::FormatHandler::Factory(output_format, output_file, &augment_params, harvest_params);
         unsigned total_record_count(0), total_previously_downloaded_count(0);
 
         std::unique_ptr<File> progress_file;
@@ -156,7 +156,7 @@ void Main(int argc, char *argv[]) {
         SimpleCrawler::ParseConfigFile(simple_crawler_config_path, &site_descs);
 
         HarvestSites(crawler_params, supported_urls_regex, site_descs,
-                     harvest_params, augment_params, progress_file,
+                     harvest_params, &augment_params, progress_file,
                      &total_record_count, &total_previously_downloaded_count);
 
         LOG_INFO("Harvested a total of " + StringUtil::ToString(total_record_count) + " records of which "

--- a/cpp/zts_harvester.cc
+++ b/cpp/zts_harvester.cc
@@ -44,9 +44,9 @@ void ProcessRSS(const IniFile::Section &section) {
     LOG_DEBUG("feed_url: " + feed_url);
 }
 
-    
+
 void ProcessCrawl(const IniFile::Section &section, const std::string &marc_output_file,
-                      std::shared_ptr<Zotero::HarvestMaps> harvest_maps)
+                  std::shared_ptr<Zotero::HarvestMaps> harvest_maps)
 {
     const std::string base_url(section.getString("base_url"));
     std::shared_ptr<RegexMatcher> extraction_regex(RegexMatcher::FactoryOrDie(section.getString("extraction_regex")));
@@ -55,7 +55,6 @@ void ProcessCrawl(const IniFile::Section &section, const std::string &marc_outpu
     const std::string optional_strptime_format(section.getString("strptime_format", ""));
 
     std::shared_ptr<Zotero::HarvestParams> harvest_params;
-    harvest_params->optional_strptime_format_ = optional_strptime_format;
     harvest_params->format_handler_.reset(new Zotero::MarcFormatHandler(marc_output_file, harvest_maps, harvest_params));
 }
 
@@ -98,7 +97,7 @@ int Main(int argc, char *argv[]) {
     std::unordered_map<std::string, bool> section_name_to_found_flag_map;
     for (int arg_no(2); arg_no < argc; ++arg_no)
         section_name_to_found_flag_map.emplace(argv[arg_no], false);
-    
+
     enum Type { RSS, CRAWL };
     const std::map<std::string, int> string_to_value_map{ {"RSS", RSS }, { "CRAWL", CRAWL } };
     unsigned processed_section_count(0);
@@ -110,7 +109,7 @@ int Main(int argc, char *argv[]) {
             section_name_and_found_flag->second = true;
         }
         ++processed_section_count;
-        
+
         LOG_INFO("Processing section \"" + section.first + "\".");
         const Type type(static_cast<Type>(section.second.getEnum("type", string_to_value_map)));
         if (type == RSS)

--- a/cpp/zts_harvester.cc
+++ b/cpp/zts_harvester.cc
@@ -84,13 +84,10 @@ int Main(int argc, char *argv[]) {
     if (not StringUtil::EndsWith(map_directory_path, '/'))
         map_directory_path += '/';
 
-    Zotero::AugmentParams augment_params;
-    augment_params.maps_ = Zotero::LoadMapFilesFromDirectory(map_directory_path);
+    Zotero::AugmentMaps augment_maps(map_directory_path);
+    Zotero::AugmentParams augment_params(&augment_maps);
     const std::shared_ptr<RegexMatcher> supported_urls_regex(Zotero::LoadSupportedURLsRegex(map_directory_path));
 
-    const std::string PREVIOUSLY_DOWNLOADED_HASHES_PATH(map_directory_path + "previously_downloaded.hashes");
-    Zotero::PreviouslyDownloadedHashesManager previously_downloaded_hashes_manager(PREVIOUSLY_DOWNLOADED_HASHES_PATH,
-                                                                                   &augment_params.maps_.previously_downloaded_);
     const std::string MARC_OUTPUT_FILE(ini_file.getString("", "marc_output_file"));
     harvest_params->format_handler_ = Zotero::FormatHandler::Factory(GetMarcFormat(MARC_OUTPUT_FILE), MARC_OUTPUT_FILE,
                                                                      &augment_params, harvest_params);

--- a/cpp/zts_harvester.cc
+++ b/cpp/zts_harvester.cc
@@ -46,7 +46,7 @@ void ProcessRSS(const IniFile::Section &section) {
 
 
 void ProcessCrawl(const IniFile::Section &section, const std::string &marc_output_file,
-                  Zotero::AugmentParams &augment_params)
+                  Zotero::AugmentParams * const augment_params)
 {
     const std::string base_url(section.getString("base_url"));
     std::shared_ptr<RegexMatcher> extraction_regex(RegexMatcher::FactoryOrDie(section.getString("extraction_regex")));
@@ -93,7 +93,7 @@ int Main(int argc, char *argv[]) {
                                                                                    &augment_params.maps_.previously_downloaded_);
     const std::string MARC_OUTPUT_FILE(ini_file.getString("", "marc_output_file"));
     harvest_params->format_handler_ = Zotero::FormatHandler::Factory(GetMarcFormat(MARC_OUTPUT_FILE), MARC_OUTPUT_FILE,
-                                                                     augment_params, harvest_params);
+                                                                     &augment_params, harvest_params);
 
     std::unordered_map<std::string, bool> section_name_to_found_flag_map;
     for (int arg_no(2); arg_no < argc; ++arg_no)
@@ -116,7 +116,7 @@ int Main(int argc, char *argv[]) {
         if (type == RSS)
             ProcessRSS(section.second);
         else
-            ProcessCrawl(section.second, MARC_OUTPUT_FILE, augment_params);
+            ProcessCrawl(section.second, MARC_OUTPUT_FILE, &augment_params);
     }
 
     if (section_name_to_found_flag_map.size() > processed_section_count) {


### PR DESCRIPTION
SiteDesc was the wrong place, because it is Crawling specific and we want something usable by Crawling+RSS, so i introduced AugmentParams.

Also fixed a time problem, see:
https://stackoverflow.com/questions/19524720/using-strptime-converting-string-to-time-but-getting-garbage

ISSN not working yet.... multiple optional parameters can not be passed due to current zts_client config file structure. Also, strptime_format not working with RSS yet.