### PR TITLE
Return expected field count as opposed to the size of the field index map in DbRow::size()

### DIFF
--- a/cpp/lib/include/DbRow.h
+++ b/cpp/lib/include/DbRow.h
@@ -49,7 +49,7 @@ public:
     DbRow &operator=(const DbRow &rhs) = default;
 
     /** \return The number of fields in the row. */
-    inline size_t size() const { return field_name_to_index_map_->size(); }
+    inline size_t size() const { return field_count_; }
 
     /** \return True if the row contains no columns, else false. */
     inline bool empty() const { return field_name_to_index_map_->empty(); }


### PR DESCRIPTION
Fixes an potential out-of-bounds exception in new_journal_alert.