### PR TITLE
Another attempt at fixing the strptime bug

### DIFF
--- a/cpp/data/zts_harvester.conf
+++ b/cpp/data/zts_harvester.conf
@@ -94,8 +94,7 @@ groups             = Stelzel
 [Bergen Journal of Criminal Law and Criminology]
 type              = RSS
 feed              = "http://boap.uib.no/index.php/BJCLCJ/gateway/plugin/WebFeedGatewayPlugin/atom"
-strptime_format   = "%Y/%m/%d|%Y-%m-%d|%Y-%m-%dT%H:%M:%S%z|%Y-%m-%dT%H:%M:%S%:z" # '%:z' is a GNU extension that works on CentOS but not on Ubuntu
-                                                                                 # we'll keep both format strings to ensure compatibility on both OSes
+strptime_format   = "%Y/%m/%d|%Y-%m-%d|%Y-%m-%dT%H:%M:%S%z"
 groups            = Stelzel
 
 [Derecho penal y criminología]

--- a/cpp/lib/include/MARC.h
+++ b/cpp/lib/include/MARC.h
@@ -622,7 +622,7 @@ enum class FileType { AUTO, BINARY, XML };
  *  \return FileType::BINARY or FileType::XML.
  *  \note   Aborts if we can't determine the file type or if it is not FileType::BINARY nor FileType::XML.
  */
-FileType GuessFileType(const std::string &filename);
+FileType GuessFileType(const std::string &filename, const bool read_file);
 
 
 class Reader {

--- a/cpp/lib/src/TimeUtil.cc
+++ b/cpp/lib/src/TimeUtil.cc
@@ -704,7 +704,7 @@ void CorrectForSymbolicTimeZone(struct tm * const /*tm*/, const std::string &tim
 }
 
 
-// if "format_string" ends with "%Z", we remove it and extract the corresponding time zone name into "*time_zone_name"
+// If "format_string" ends with "%Z", we remove it and extract the corresponding time zone name into "*time_zone_name".
 static void ExtractOptionalTimeZoneName(std::string * const date_str, std::string * const format_string, std::string * const time_zone_name) {
     if (StringUtil::EndsWith(*format_string, "%Z")) {
         *format_string = StringUtil::RightTrim(format_string->substr(0, format_string->length() - 2));
@@ -721,9 +721,8 @@ static void ExtractOptionalTimeZoneName(std::string * const date_str, std::strin
 }
 
 
-// strips out the colon in the date string to preserve compatibility with CentOS
+// Strips out the colon in the date string to preserve compatibility with CentOS.
 static void NormalizeTimeZoneOffset(std::string * const date_str) {
-    // only handles the ISO8601 format at the moment
     static RegexMatcher * const matcher_iso8601(RegexMatcher::RegexMatcherFactory(
         "[0-9]{4}-[0-9]{2}-[0-9]{2}([[:space:]]|T){1}[0-9]{2}:[0-9]{2}:[0-9]{2}(\\+|\\-|\\s){1}[0-9]{2}(:)[0-9]{2}"));
 
@@ -732,12 +731,12 @@ static void NormalizeTimeZoneOffset(std::string * const date_str) {
 }
 
 
-// strptime()/CentOS idiosyncrasies:
-//      - supports "%Z" to denote time zone names, but it doesn't perfom the time conversion
-//        also, the above format specifier is apparently broken on CentOS
-//        so, we need to override the behaviour on our end
-//      - "%z" does not support a colon in the time zone offset on CentOS
-//        so, we need to strip it out before we pass it to the function
+// Strptime()/CentOS idiosyncrasies:
+//      - Strptime() supports "%Z" to denote time zone names, but it doesn't perfom the time conversion.
+//        Furthermore, the above format specifier is apparently broken on CentOS.
+//        So, we need to override the behaviour on our end.
+//      - "%z" does not support a colon in the time zone offset on CentOS.
+//        So, we need to strip it out before we pass it to the function.
 struct tm StringToStructTm(std::string date_str, std::string optional_strptime_format) {
     struct tm tm;
 

--- a/cpp/lib/src/TimeUtil.cc
+++ b/cpp/lib/src/TimeUtil.cc
@@ -704,7 +704,7 @@ void CorrectForSymbolicTimeZone(struct tm * const /*tm*/, const std::string &tim
 }
 
 
-// If "format_string" ends with "%Z", we remove it and extract the corresponding time zone name into "*time_zone_name"
+// if "format_string" ends with "%Z", we remove it and extract the corresponding time zone name into "*time_zone_name"
 static void ExtractOptionalTimeZoneName(std::string * const date_str, std::string * const format_string, std::string * const time_zone_name) {
     if (StringUtil::EndsWith(*format_string, "%Z")) {
         *format_string = StringUtil::RightTrim(format_string->substr(0, format_string->length() - 2));
@@ -721,9 +721,23 @@ static void ExtractOptionalTimeZoneName(std::string * const date_str, std::strin
 }
 
 
-// strptime() supports "%Z" to denote time zone names, but it doesn't perfom the time conversion
-// also, the above format specifier is apparently broken on CentOS
-// so, we need to override the behaviour on our end
+// strips out the colon in the date string to preserve compatibility with CentOS
+static void NormalizeTimeZoneOffset(std::string * const date_str) {
+    // only handles the ISO8601 format at the moment
+    static RegexMatcher * const matcher_iso8601(RegexMatcher::RegexMatcherFactory(
+        "[0-9]{4}-[0-9]{2}-[0-9]{2}([[:space:]]|T){1}[0-9]{2}:[0-9]{2}:[0-9]{2}(\\+|\\-|\\s){1}[0-9]{2}(:)[0-9]{2}"));
+
+    if (matcher_iso8601->matched(*date_str))
+        date_str->erase(date_str->length() - 3, 1);
+}
+
+
+// strptime()/CentOS idiosyncrasies:
+//      - supports "%Z" to denote time zone names, but it doesn't perfom the time conversion
+//        also, the above format specifier is apparently broken on CentOS
+//        so, we need to override the behaviour on our end
+//      - "%z" does not support a colon in the time zone offset on CentOS
+//        so, we need to strip it out before we pass it to the function
 struct tm StringToStructTm(std::string date_str, std::string optional_strptime_format) {
     struct tm tm;
 
@@ -741,6 +755,8 @@ struct tm StringToStructTm(std::string date_str, std::string optional_strptime_f
             locale.reset(new Locale(locale_specification, LC_TIME));
             optional_strptime_format = optional_strptime_format.substr(closing_paren_pos + 1);
         }
+
+        NormalizeTimeZoneOffset(&date_str);
 
         std::vector<std::string> format_string_splits;
         // try available format strings until a matching one is found

--- a/cpp/lib/src/Zotero.cc
+++ b/cpp/lib/src/Zotero.cc
@@ -234,7 +234,7 @@ std::pair<unsigned, unsigned> ZoteroFormatHandler::processRecord(const std::shar
 
 
 std::string GuessOutputFormat(const std::string &output_file) {
-    switch (MARC::GuessFileType(output_file, /* read_file = */ true)) {
+    switch (MARC::GuessFileType(output_file, /* read_file = */ false)) {
     case MARC::FileType::BINARY:
         return "marc21";
     case MARC::FileType::XML:

--- a/cpp/lib/src/Zotero.cc
+++ b/cpp/lib/src/Zotero.cc
@@ -234,7 +234,7 @@ std::pair<unsigned, unsigned> ZoteroFormatHandler::processRecord(const std::shar
 
 
 std::string GuessOutputFormat(const std::string &output_file) {
-    switch (MARC::GuessFileType(output_file)) {
+    switch (MARC::GuessFileType(output_file, /* read_file = */ true)) {
     case MARC::FileType::BINARY:
         return "marc21";
     case MARC::FileType::XML:

--- a/cpp/zts_harvester.cc
+++ b/cpp/zts_harvester.cc
@@ -137,7 +137,7 @@ UnsignedPair ProcessDirectHarvest(const IniFile::Section &section, const std::sh
 
 
 std::string GetMarcFormat(const std::string &output_filename) {
-    switch (MARC::GuessFileType(output_filename)) {
+    switch (MARC::GuessFileType(output_filename, /* read_file = */ true)) {
     case MARC::FileType::BINARY:
         return "marc21";
     case MARC::FileType::XML:

--- a/cpp/zts_harvester.cc
+++ b/cpp/zts_harvester.cc
@@ -137,7 +137,7 @@ UnsignedPair ProcessDirectHarvest(const IniFile::Section &section, const std::sh
 
 
 std::string GetMarcFormat(const std::string &output_filename) {
-    switch (MARC::GuessFileType(output_filename, /* read_file = */ true)) {
+    switch (MARC::GuessFileType(output_filename, /* read_file = */ false)) {
     case MARC::FileType::BINARY:
         return "marc21";
     case MARC::FileType::XML:


### PR DESCRIPTION
Turns out the "%:z" format specifier works with the built-in date command but not with strptime :man_facepalming: I just went with the original plan of matching the date string with the expect format in the standard and stripping out the colon.