### PR TITLE
Temporarily disable the sorting of fields after reading in MARC recor…

### DIFF
--- a/cpp/lib/include/MARC.h
+++ b/cpp/lib/include/MARC.h
@@ -521,7 +521,7 @@ public:
     inline const Field &back() const { return fields_.back(); }
 
     // Alphanumerically sorts the fields in the range [begin_field, end_field).
-    void sortFields(const iterator &begin_field, const iterator &end_field) { std::stable_sort(begin_field, end_field); }
+    void sortFields(const iterator &begin_field, const iterator &end_field) { std::sort(begin_field, end_field); }
 
     /** \return Iterators pointing to the half-open interval of the first range of fields corresponding to the tag "tag".
      *  \remark {

--- a/cpp/lib/src/MARC.cc
+++ b/cpp/lib/src/MARC.cc
@@ -707,7 +707,7 @@ Record BinaryReader::read() {
     } while (new_record.getControlNumber() == last_record_.getControlNumber());
 
     new_record.swap(last_record_);
-    new_record.sortFields(new_record.begin(), new_record.end());
+    // new_record.sortFields(new_record.begin(), new_record.end());
     return new_record;
 }
 
@@ -750,7 +750,7 @@ Record XmlReader::read() {
         /* Intentionally empty! */;
 
     if (unlikely(type == SimpleXmlParser<File>::CLOSING_TAG and data == namespace_prefix_ + "collection")) {
-        new_record.sortFields(new_record.begin(), new_record.end());
+        // new_record.sortFields(new_record.begin(), new_record.end());
         return new_record;
     }
 
@@ -788,7 +788,7 @@ Record XmlReader::read() {
                 throw std::runtime_error("in MARC::MarcUtil::Record::XmlFactory: closing </record> tag expected "
                                          "while parsing \"" + input_->getPath() + "\" on line "
                                          + std::to_string(xml_parser_->getLineNo()) + "!");
-            new_record.sortFields(new_record.begin(), new_record.end());
+            // new_record.sortFields(new_record.begin(), new_record.end());
             return new_record;
         }
 


### PR DESCRIPTION
…ds (breaks local data blocks)

Mario and I were able to narrow the error message on ptah (Every local data block has to have exactly one 001 field) down to these offending lines. Seems like the sort method is not fully accounting for local data fields?