### PR TITLE
fixed python regex problem

### DIFF
--- a/cronjobs/util.py
+++ b/cronjobs/util.py
@@ -209,9 +209,9 @@ def LoadConfigFile(path=None, no_error=False):
 def ExtractAndRenameBSZFiles(gzipped_tar_archive, name_prefix = None):
     # Ensures that all members of "gzipped_tar_archive" match our expectation as to what the BSZ should deliver.
     def TarFileMemberNamesAreOkOrDie(tar_file, archive_name):
-        compiled_pattern = re.compile("[a-z]+00\\d.raw$")
+        compiled_pattern = re.compile("[a-z]+00\\d\\.raw$")
         for member in tar_file.getnames():
-            if not compiled_pattern.match(member):
+            if not compiled_pattern.search(member):
                 Error("unknown tar file member \"" + member + "\" in \"" + archive_name + "\"!")
 
 


### PR DESCRIPTION
use search() instead of match() if string is not required to begin at position 0, see
https://docs.python.org/2/library/re.html#re.RegexObject.search