### PR TITLE
Zotero: clamp down on logging and make error messages parsable by other tools

### DIFF
--- a/cpp/lib/src/SyndicationFormat.cc
+++ b/cpp/lib/src/SyndicationFormat.cc
@@ -187,7 +187,7 @@ std::unique_ptr<SyndicationFormat::Item> RSS20::getNextItem() {
     XMLParser::XMLPart part;
     while (xml_parser_.getNext(&part)) {
         if (part.type_ == XMLParser::XMLPart::CLOSING_TAG and part.data_ == "item") {
-            LOG_INFO("found new item: " + title + ", URL: " + link);
+            LOG_DEBUG("found new item: " + title + ", URL: " + link);
             return std::unique_ptr<SyndicationFormat::Item>(new Item(title, description, link, id, pub_date));
         } else if (part.type_ == XMLParser::XMLPart::OPENING_TAG and part.data_ == "title")
             title = ExtractText(xml_parser_, "title", " (RSS20::getNextItem)");

--- a/cpp/zts_harvester.cc
+++ b/cpp/zts_harvester.cc
@@ -175,7 +175,7 @@ int Main(int argc, char *argv[]) {
         --argc, ++argv;
     }
 
-    std::set<std::string> groups_filter;
+    std::unordered_set<std::string> groups_filter;
     if (StringUtil::StartsWith(argv[1], "--groups=")) {
         StringUtil::SplitThenTrimWhite(argv[1] + __builtin_strlen("--groups="), ',', &groups_filter);
         --argc, ++argv;
@@ -258,6 +258,8 @@ int Main(int argc, char *argv[]) {
         const auto group_name_and_params(group_name_to_params_map.find(group_name));
         if (group_name_and_params == group_name_to_params_map.cend())
             LOG_ERROR("unknown or undefined group \"" + group_name + "\" in section \"" + section.getSectionName() + "\"!");
+        else if (not groups_filter.empty() and groups_filter.find(group_name) == groups_filter.end())
+            continue;
 
         std::vector<MARC::EditInstruction> edit_instructions;
         LoadMARCEditInstructions(section, &edit_instructions);


### PR DESCRIPTION
The plan is to write a Zeder-Zotero pipeline that automatically fetches data from Zeder, converts it to the Zotero format, performs automated tests. The idea is to reduce the amount of manual intervention required to get a journal into the harvester system.