### PR TITLE
exclude SSLv2 in apache conf no longer necessary because it's depreca…

### DIFF
--- a/docker/ixtheo-centos/httpd/vufind-vhosts.conf
+++ b/docker/ixtheo-centos/httpd/vufind-vhosts.conf
@@ -16,7 +16,7 @@ SetEnv      VUFIND_HOME /usr/local/vufind
     ScriptAlias /cgi-bin/ /var/www/cgi-bin/
     ScriptAlias /tools/ /var/www/tools/
     SSLEngine On
-    SSLProtocol all -SSLv2 -SSLv3
+    SSLProtocol all -SSLv3
     SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
     SSLCertificateFile /etc/ssl/certs/localhost-cert.pem
     SSLCertificateKeyFile /etc/ssl/certs/localhost-key.pem
@@ -38,7 +38,7 @@ SetEnv      VUFIND_HOME /usr/local/vufind
     ScriptAlias /cgi-bin/ /var/www/cgi-bin/
     ScriptAlias /tools/ /var/www/tools/
     SSLEngine On
-    SSLProtocol all -SSLv2 -SSLv3
+    SSLProtocol all -SSLv3
     SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
     SSLCertificateFile /etc/ssl/certs/localhost-cert.pem
     SSLCertificateKeyFile /etc/ssl/certs/localhost-key.pem
@@ -60,7 +60,7 @@ SetEnv      VUFIND_HOME /usr/local/vufind
     ScriptAlias /cgi-bin/ /var/www/cgi-bin/
     ScriptAlias /tools/ /var/www/tools/
     SSLEngine On
-    SSLProtocol all -SSLv2 -SSLv3
+    SSLProtocol all -SSLv3
     SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
     SSLCertificateFile /etc/ssl/certs/localhost-cert.pem
     SSLCertificateKeyFile /etc/ssl/certs/localhost-key.pem

--- a/docker/ixtheo-ubuntu/apache2/vufind-vhosts.conf
+++ b/docker/ixtheo-ubuntu/apache2/vufind-vhosts.conf
@@ -16,7 +16,7 @@ SetEnv      VUFIND_HOME /usr/local/vufind
     ScriptAlias /cgi-bin/ /var/www/cgi-bin/
     ScriptAlias /tools/ /var/www/tools/
     SSLEngine On
-    SSLProtocol all -SSLv2 -SSLv3
+    SSLProtocol all -SSLv3
     SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
     SSLCertificateFile /etc/ssl/certs/localhost-cert.pem
     SSLCertificateKeyFile /etc/ssl/certs/localhost-key.pem
@@ -38,7 +38,7 @@ SetEnv      VUFIND_HOME /usr/local/vufind
     ScriptAlias /cgi-bin/ /var/www/cgi-bin/
     ScriptAlias /tools/ /var/www/tools/
     SSLEngine On
-    SSLProtocol all -SSLv2 -SSLv3
+    SSLProtocol all -SSLv3
     SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
     SSLCertificateFile /etc/ssl/certs/localhost-cert.pem
     SSLCertificateKeyFile /etc/ssl/certs/localhost-key.pem
@@ -60,7 +60,7 @@ SetEnv      VUFIND_HOME /usr/local/vufind
     ScriptAlias /cgi-bin/ /var/www/cgi-bin/
     ScriptAlias /tools/ /var/www/tools/
     SSLEngine On
-    SSLProtocol all -SSLv2 -SSLv3
+    SSLProtocol all -SSLv3
     SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
     SSLCertificateFile /etc/ssl/certs/localhost-cert.pem
     SSLCertificateKeyFile /etc/ssl/certs/localhost-key.pem

--- a/docker/krimdok-centos/httpd/vufind-vhosts.conf
+++ b/docker/krimdok-centos/httpd/vufind-vhosts.conf
@@ -18,7 +18,7 @@ SetEnv      VUFIND_HOME /usr/local/vufind
     ServerName 127.0.0.1
     ServerAlias docker
     SSLEngine On
-    SSLProtocol all -SSLv2 -SSLv3
+    SSLProtocol all -SSLv3
     SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
     SSLCertificateFile /etc/ssl/certs/localhost-cert.pem
     SSLCertificateKeyFile /etc/ssl/certs/localhost-key.pem
@@ -40,7 +40,7 @@ SetEnv      VUFIND_HOME /usr/local/vufind
     ScriptAlias /cgi-bin/ /var/www/cgi-bin/
     ScriptAlias /tools/ /var/www/tools/
     SSLEngine On
-    SSLProtocol all -SSLv2 -SSLv3
+    SSLProtocol all -SSLv3
     SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
     SSLCertificateFile /etc/ssl/certs/localhost-cert.pem
     SSLCertificateKeyFile /etc/ssl/certs/localhost-key.pem

--- a/docker/krimdok-ubuntu/apache2/vufind-vhosts.conf
+++ b/docker/krimdok-ubuntu/apache2/vufind-vhosts.conf
@@ -18,7 +18,7 @@ SetEnv      VUFIND_HOME /usr/local/vufind
     ServerName 127.0.0.1
     ServerAlias docker
     SSLEngine On
-    SSLProtocol all -SSLv2 -SSLv3
+    SSLProtocol all -SSLv3
     SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
     SSLCertificateFile /etc/ssl/certs/localhost-cert.pem
     SSLCertificateKeyFile /etc/ssl/certs/localhost-key.pem
@@ -40,7 +40,7 @@ SetEnv      VUFIND_HOME /usr/local/vufind
     ScriptAlias /cgi-bin/ /var/www/cgi-bin/
     ScriptAlias /tools/ /var/www/tools/
     SSLEngine On
-    SSLProtocol all -SSLv2 -SSLv3
+    SSLProtocol all -SSLv3
     SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
     SSLCertificateFile /etc/ssl/certs/localhost-cert.pem
     SSLCertificateKeyFile /etc/ssl/certs/localhost-key.pem

--- a/docker/ub_tools-centos/httpd/ub_tools-vhosts.conf
+++ b/docker/ub_tools-centos/httpd/ub_tools-vhosts.conf
@@ -14,7 +14,7 @@ DocumentRoot /var/www/cgi-bin
     ServerName 127.0.0.1
     ServerAlias docker
     SSLEngine On
-    SSLProtocol all -SSLv2 -SSLv3
+    SSLProtocol all -SSLv3
     SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
     SSLCertificateFile /etc/ssl/certs/localhost-cert.pem
     SSLCertificateKeyFile /etc/ssl/certs/localhost-key.pem
@@ -29,7 +29,7 @@ DocumentRoot /var/www/cgi-bin
     ServerName localhost
     ServerAlias localhost
     SSLEngine On
-    SSLProtocol all -SSLv2 -SSLv3
+    SSLProtocol all -SSLv3
     SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
     SSLCertificateFile /etc/ssl/certs/localhost-cert.pem
     SSLCertificateKeyFile /etc/ssl/certs/localhost-key.pem


### PR DESCRIPTION
…ted by mod_ssl

see https://httpd.apache.org/docs/2.4/mod/mod_ssl.html