### PR TITLE
add support for publication year whilst importing full text

### DIFF
--- a/cpp/journal_publishing_processor.cc
+++ b/cpp/journal_publishing_processor.cc
@@ -39,70 +39,69 @@ namespace {
 }
 
 
-bool ExtractTitle(XMLParser * const xml_parser, std::string * const article_title) {
-    article_title->clear();
+struct Metadata {
+    std::string title_;
+    std::set<std::string> authors_;
+    std::string publication_year_;
+};
 
-    if (not xml_parser->skipTo(XMLParser::XMLPart::OPENING_TAG, "article-title"))
-        return false;
 
+std::string ReadCharactersUntilNextClosingTag(XMLParser * const xml_parser, const std::string &closing_tag = "") {
     XMLParser::XMLPart xml_part;
+    std::string extracted_data;
+
     while (xml_parser->getNext(&xml_part)) {
-        if (xml_part.type_ == XMLParser::XMLPart::CLOSING_TAG and xml_part.data_ == "article-title")
-            return not article_title->empty();
-        if (xml_part.type_ == XMLParser::XMLPart::CHARACTERS)
-            *article_title += xml_part.data_;
+        if (xml_part.isClosingTag() and (closing_tag.empty() or xml_part.data_ == closing_tag))
+            break;
+        else if (xml_part.type_ == XMLParser::XMLPart::CHARACTERS)
+            extracted_data += xml_part.data_;
     }
 
-    return false;
+    return extracted_data;
 }
 
 
-bool ExtractAuthor(XMLParser * const xml_parser, std::set<std::string> * const article_authors) {
+void ExtractAuthor(XMLParser * const xml_parser, std::set<std::string> * const article_authors) {
     if (not xml_parser->skipTo(XMLParser::XMLPart::OPENING_TAG, "surname"))
-        return false;
+        return;
 
     XMLParser::XMLPart xml_part;
     if (not xml_parser->getNext(&xml_part) or xml_part.type_ != XMLParser::XMLPart::CHARACTERS)
-        return false;
+        return;
     std::string surname(xml_part.data_);
 
     while (xml_parser->getNext(&xml_part)) {
         if (xml_part.type_ == XMLParser::XMLPart::CLOSING_TAG and xml_part.data_ == "contrib") {
             article_authors->insert(surname);
-            return true;
+            return;
         } else if (xml_part.type_ == XMLParser::XMLPart::OPENING_TAG and xml_part.data_ == "given-names") {
             if (not xml_parser->getNext(&xml_part) or xml_part.type_ != XMLParser::XMLPart::CHARACTERS)
-                return false;
+                return;
             article_authors->insert(xml_part.data_ + " " + surname);
-            return true;
+            return;
         }
     }
-
-    return false;
 }
 
 
-bool ExtractAuthors(XMLParser * const xml_parser, std::set<std::string> * const article_authors) {
+void ExtractMetadata(XMLParser * const xml_parser, Metadata * const metadata) {
     XMLParser::XMLPart xml_part;
+
     while (xml_parser->getNext(&xml_part)) {
-        if (xml_part.type_ == XMLParser::XMLPart::OPENING_TAG) {
-            if (xml_part.data_ == "abstract" or xml_part.data_ == "body")
-                return true;
-            else if (xml_part.data_ == "contrib") {
-                const auto contrib_type_and_value(xml_part.attributes_.find("contrib-type"));
-                if (contrib_type_and_value != xml_part.attributes_.cend() and contrib_type_and_value->second == "author") {
-                    if (not ExtractAuthor(xml_parser, article_authors))
-                        return false;
-                }
-            }
+        if (xml_part.isOpeningTag("article-title"))
+            metadata->title_ = ReadCharactersUntilNextClosingTag(xml_parser);
+        else if (xml_part.isOpeningTag("contrib")) {
+            const auto contrib_type_and_value(xml_part.attributes_.find("contrib-type"));
+            if (contrib_type_and_value != xml_part.attributes_.cend() and contrib_type_and_value->second == "author")
+                ExtractAuthor(xml_parser, &metadata->authors_);
+        } else if (xml_part.isOpeningTag("pub-date")) {
+            if (xml_parser->skipTo(XMLParser::XMLPart::OPENING_TAG, "year"))
+                metadata->publication_year_ = ReadCharactersUntilNextClosingTag(xml_parser);
         }
     }
-
-    return false;
 }
 
 
-// Extracts abstracts and bodies.
 bool ExtractText(XMLParser * const xml_parser, const std::string &text_opening_tag, std::string * const text) {
     xml_parser->rewind();
 
@@ -130,30 +129,33 @@ bool ExtractText(XMLParser * const xml_parser, const std::string &text_opening_t
 }
 
 
-void ProcessDocument(const bool normalise_only, XMLParser * const xml_parser, File * const plain_text_output) {
-    std::string article_title;
-    if (not ExtractTitle(xml_parser, &article_title))
-        LOG_ERROR("no article title found!");
+void ProcessDocument(const bool normalise_only, const std::string &input_file_path, XMLParser * const xml_parser, File * const plain_text_output) {
+    Metadata full_text_metadata;
+    ExtractMetadata(xml_parser, &full_text_metadata);
 
-    std::set<std::string> article_authors;
-    if (not ExtractAuthors(xml_parser, &article_authors))
-        LOG_ERROR("no article authors found or an error or end-of-document were found while trying to extract an author name!");
+    if (full_text_metadata.title_.empty())
+        LOG_ERROR("no article title found in file '" + input_file_path + "'");
+
+    if (full_text_metadata.authors_.empty())
+        LOG_ERROR("no article authors found in file '" + input_file_path + "'");
 
     if (normalise_only) {
-        std::cout << ControlNumberGuesser::NormaliseTitle(article_title) << '\n';
-        for (const auto &article_author : article_authors)
+        std::cout << ControlNumberGuesser::NormaliseTitle(full_text_metadata.title_) << '\n';
+        for (const auto &article_author : full_text_metadata.authors_)
             std::cout << ControlNumberGuesser::NormaliseAuthorName(article_author) << '\n';
         return;
     }
 
     std::string full_text, abstract;
-    ExtractText(xml_parser, "body", &full_text);
-    ExtractText(xml_parser, "abstract", &abstract);
+    if (not ExtractText(xml_parser, "body", &full_text))
+        ExtractText(xml_parser, "abstract", &abstract);
 
     if (full_text.empty() and abstract.empty())
-        LOG_ERROR("Neither full-text nor abstract text was found");
+        LOG_ERROR("Neither full-text nor abstract text was found in file '" + input_file_path + "'");
 
-    FullTextImport::WriteExtractedTextToDisk(not full_text.empty() ? full_text : abstract, article_title, article_authors, plain_text_output);
+    FullTextImport::WriteExtractedTextToDisk(not full_text.empty() ? full_text : abstract,
+                                             full_text_metadata.title_, full_text_metadata.authors_, full_text_metadata.publication_year_,
+                                             plain_text_output);
 }
 
 
@@ -175,7 +177,7 @@ int Main(int argc, char *argv[]) {
 
     XMLParser xml_parser (argv[1], XMLParser::XML_FILE);
     auto plain_text_output(normalise_only ? nullptr : FileUtil::OpenOutputFileOrDie(argv[2]));
-    ProcessDocument(normalise_only, &xml_parser, plain_text_output.get());
+    ProcessDocument(normalise_only, argv[1], &xml_parser, plain_text_output.get());
 
     return EXIT_SUCCESS;
 }

--- a/cpp/lib/include/ControlNumberGuesser.h
+++ b/cpp/lib/include/ControlNumberGuesser.h
@@ -47,7 +47,7 @@ public:
     void insertTitle(const std::string &title, const std::string &control_number);
     void insertAuthors(const std::set<std::string> &authors, const std::string &control_number);
     void insertYear(const std::string &year, const std::string &control_number);
-    std::set<std::string> getGuessedControlNumbers(const std::string &title, const std::vector<std::string> &authors,
+    std::set<std::string> getGuessedControlNumbers(const std::string &title, const std::set<std::string> &authors,
                                                    const std::string &year = "") const;
 
     bool getNextTitle(std::string * const title, std::set<std::string> * const control_numbers) const;

--- a/cpp/lib/include/FullTextImport.h
+++ b/cpp/lib/include/FullTextImport.h
@@ -43,22 +43,29 @@ extern const std::string PARAGRAPH_DELIMITER;
 // The actual full-text consists of multiple chunks of arbitrary text sequences.
 // What constitutes a chunk is dependent on the source of the full-text.
 struct FullTextData {
-    std::string normalised_title_;
-    std::set<std::string> normalised_authors_;
+    std::string title_;
+    std::set<std::string> authors_;
+    std::string year_;
     std::vector<std::string> full_text_;
 };
 
 
 // Writes full-text data as a text file to disk. The full-text is expected to be split into chunks and formatted in the following manner:
-// Line 1: <normalized_title>
-// Line 2: <normalized authors>
-// Line 3...: <full_text>
-void WriteExtractedTextToDisk(const std::string &full_text, const std::string &normalised_title,
-                              const std::set<std::string> &normalised_authors, File * const output_file);
+// Line 1: <title>
+// Line 2: <authors>
+// Line 3: <year>
+// Line 4: <full_text>
+void WriteExtractedTextToDisk(const std::string &full_text, const std::string &title,
+                              const std::set<std::string> &authors, const std::string &year, File * const output_file);
 
 
 // Reads in and parses a text file previously written to disk with WriteExtractedTextToDisk() into a FullTextData instance.
 void ReadExtractedTextFromDisk(File * const input_file, FullTextData * const full_text_data);
+
+
+// Match full-text data with an existing record's control number, if any. Returns the number of exact matches.
+size_t CorrelateFullTextData(const std::vector<std::shared_ptr<FullTextData>> &full_text_data,
+                            std::unordered_map<std::string, std::shared_ptr<FullTextData>> * const control_number_to_full_text_data_map);
 
 
 } // namespace FullTextImport

--- a/cpp/lib/src/ControlNumberGuesser.cc
+++ b/cpp/lib/src/ControlNumberGuesser.cc
@@ -45,12 +45,12 @@ static const std::string MATCH_DB_PREFIX("/usr/local/var/lib/tuelib/normalised_"
 
 
 ControlNumberGuesser::ControlNumberGuesser(const OpenMode open_mode)
-    : MAX_CONTROL_NUMBER_LENGTH(BSZUtil::PPN_LENGTH_NEW), title_cursor_(nullptr), author_cursor_(nullptr)
+    : MAX_CONTROL_NUMBER_LENGTH(BSZUtil::PPN_LENGTH_NEW), title_cursor_(nullptr), author_cursor_(nullptr), year_cursor_(nullptr)
 {
     const std::string TITLES_DB_PATH(MATCH_DB_PREFIX + "titles.db");
     const std::string AUTHORS_DB_PATH(MATCH_DB_PREFIX + "authors.db");
-    const std::string YEARS_DB_PATH(MATCH_DB_PREFIX + "years.db");
 
+    const std::string YEARS_DB_PATH(MATCH_DB_PREFIX + "years.db");
     if (open_mode == CLEAR_DATABASES) {
         ::unlink(TITLES_DB_PATH.c_str());
         ::unlink(AUTHORS_DB_PATH.c_str());
@@ -136,12 +136,11 @@ void ControlNumberGuesser::insertYear(const std::string &year, const std::string
 }
 
 
-std::set<std::string> ControlNumberGuesser::getGuessedControlNumbers(const std::string &title, const std::vector<std::string> &authors,
+std::set<std::string> ControlNumberGuesser::getGuessedControlNumbers(const std::string &title, const std::set<std::string> &authors,
                                                                      const std::string &year) const
 {
     const auto normalised_title(NormaliseTitle(title));
-    if (logger->getMinimumLogLevel() >= Logger::LL_DEBUG)
-        LOG_DEBUG("in ControlNumberGuesser::getGuessedControlNumbers: normalised_title=\"" + normalised_title + "\".");
+    LOG_DEBUG("in ControlNumberGuesser::getGuessedControlNumbers: normalised_title=\"" + normalised_title + "\".");
     std::string concatenated_title_control_numbers;
     std::vector<std::string> title_control_numbers;
     if (not titles_db_->get(normalised_title, &concatenated_title_control_numbers)
@@ -154,8 +153,7 @@ std::set<std::string> ControlNumberGuesser::getGuessedControlNumbers(const std::
     std::vector<std::string> all_author_control_numbers;
     for (const auto &author : authors) {
         const auto normalised_author(NormaliseAuthorName(author));
-        if (logger->getMinimumLogLevel() >= Logger::LL_DEBUG)
-            LOG_DEBUG("in ControlNumberGuesser::getGuessedControlNumbers: normalised_author=\"" + normalised_author + "\".");
+        LOG_DEBUG("in ControlNumberGuesser::getGuessedControlNumbers: normalised_author=\"" + normalised_author + "\".");
         std::string concatenated_author_control_numbers;
         std::set<std::string> author_control_numbers;
         if (authors_db_->get(normalised_author, &concatenated_author_control_numbers)) {


### PR DESCRIPTION
Unfortunately, the new additions are broken. With the year constraint, we seem to be dropping _all_ records. Will need to be investigated.