### PR TITLE
Zotero: add indicators '0' and '8' when any of 773$iaxw are present in addition to 773$g

### DIFF
--- a/cpp/lib/src/Zotero.cc
+++ b/cpp/lib/src/Zotero.cc
@@ -534,6 +534,8 @@ void MarcFormatHandler::GenerateMarcRecord(MARC::Record * const record, const st
     const std::string volume(node_parameters.volume);
 
     // 773g, example: "52(2018), 1, S. 1-40" => <volume>(<year>), <issue>, S. <pages>
+    const bool _773_subfields_iaxw_present(not _773_subfields.empty());
+    bool _773_subfield_g_present(false);
     std::string g_content;
     if (not volume.empty()) {
         g_content += volume;
@@ -551,8 +553,13 @@ void MarcFormatHandler::GenerateMarcRecord(MARC::Record * const record, const st
             g_content += ", S. " + pages;
 
         _773_subfields.appendSubfield('g', g_content);
+        _773_subfield_g_present = true;
     }
-    record->insertField("773", _773_subfields);
+
+    if (_773_subfields_iaxw_present and _773_subfield_g_present)
+        record->insertField("773", _773_subfields, '0', '8');
+    else
+        record->insertField("773", _773_subfields);
 
     // Keywords
     BSZTransform::BSZTransform bsz_transform(*(site_params_->global_params_->maps_));


### PR DESCRIPTION
refs ubtue/DatenProbleme#120.