### PR TITLE
use 773t instead of 773a when generating MARC in Zotero context

### DIFF
--- a/cpp/archive_records.cc
+++ b/cpp/archive_records.cc
@@ -78,7 +78,7 @@ void StoreRecords(DbConnection * const db_connection, MARC::Reader * const marc_
 
         std::string superior_title;
         for (const auto &_773_field : record.getTagRange("773")) {
-            superior_title = _773_field.getFirstSubfieldWithCode('a');
+            superior_title = _773_field.getFirstSubfieldWithCode('t');
             if (not superior_title.empty())
                 break;
         }

--- a/cpp/lib/src/Zotero.cc
+++ b/cpp/lib/src/Zotero.cc
@@ -523,7 +523,7 @@ void MarcFormatHandler::GenerateMarcRecord(MARC::Record * const record, const st
     const std::string publication_title(node_parameters.publication_title);
     if (not publication_title.empty()) {
         _773_subfields.appendSubfield('i', "In: ");
-        _773_subfields.appendSubfield('a', publication_title);
+        _773_subfields.appendSubfield('t', publication_title);
     }
     const std::string issn(node_parameters.issn);
     if (not issn.empty())


### PR DESCRIPTION
see ubtue/DatenProbleme#125