### PR TITLE
changed squid conf. Resources with URLs containing "?" now will also …

### DIFF
--- a/docker/squidproxy/squid.conf
+++ b/docker/squidproxy/squid.conf
@@ -2410,8 +2410,9 @@ debug_options ALL,1
 #Suggested default:
 #refresh_pattern ^ftp:		1440	20%	10080
 #refresh_pattern ^gopher:	1440	0%	1440
-refresh_pattern (cgi-bin|\?)	0	0%	0
-refresh_pattern .		1000	100%	10080 	 override-expire override-lastmod reload-into-ims ignore-reload  ignore-no-cache ignore-no-store ignore-must-revalidate ignore-private ignore-auth refresh-ims
+#refresh_pattern (cgi-bin|\?)	0	0%	0
+refresh_pattern (cgi-bin)	0	0%	0
+refresh_pattern .		720	100%	1000 	 override-expire override-lastmod reload-into-ims ignore-reload  ignore-no-cache ignore-no-store ignore-must-revalidate ignore-private ignore-auth refresh-ims
 
 #  TAG: quick_abort_min	(KB)
 #  TAG: quick_abort_max	(KB)


### PR DESCRIPTION
…be cached. Caching timespan adjusted to 12~16 hours.

note: Resources with URLs have been listed in cache, but with a "REVALIDATE_ALWAYS" option, which is not what we want to achieve.