### PR TITLE
rss_aggregator: fix temp file path, fix double-free

### DIFF
--- a/cpp/lib/include/XmlWriter.h
+++ b/cpp/lib/include/XmlWriter.h
@@ -52,7 +52,7 @@ private:
     Attributes next_attributes_;
 public:
     /** \brief  Instantiate an XmlWriter object.
-     *  \param  output_file                      Where to write the generated XML to.
+     *  \param  output_file                      Where to write the generated XML to. Assumes ownership of the pointer.
      *  \param  xml_declaration_write_behaviour  Whether to write an XML declaration or not.
      *  \param  indent_amount                    How many leading spaces to add per indentation level.
      *  \param  text_conversion_type             What kind, if any, of text conversion to apply on output.

--- a/cpp/lib/src/FileUtil.cc
+++ b/cpp/lib/src/FileUtil.cc
@@ -1305,7 +1305,10 @@ std::string GetPathFromFileDescriptor(const int fd) {
 
         if (static_cast<size_t>(path_size) < buf_size) {
             buf[path_size] = '\0';
-            return buf;
+
+            const std::string str_buf(buf);
+            std::free(buf);
+            return str_buf;
         }
     }
 }


### PR DESCRIPTION
Clarify ownership rules in XmlWriter c'tor
Fix memory-leak in FileUtil::GetGetPathFromFileDescriptor