### PR TITLE
improved SystemdUtil::IsAvailable

### DIFF
--- a/cpp/lib/src/ExecUtil.cc
+++ b/cpp/lib/src/ExecUtil.cc
@@ -427,18 +427,11 @@ std::string GetOriginalCommandNameFromPID(const pid_t pid) {
         LOG_ERROR("Neither /bin/ps nor /usr/bin/ps can be found!");
 
     std::string stdout_output;
-    const int retcode(ExecSubcommandAndCaptureStdout(ps_path + " --pid " + std::to_string(pid) + " --no-headers -o comm",
-                                                     &stdout_output, /* suppress_stderr = */true));
-    if (unlikely(retcode == 127))
-        LOG_ERROR("can't execute " + ps_path + "!");
-
-    if (retcode == 1)
+    if (not ExecSubcommandAndCaptureStdout(ps_path + " --pid " + std::to_string(pid) + " --no-headers -o comm",
+                                           &stdout_output, /* suppress_stderr = */true))
         return "";
-
-    if (retcode != 0)
-        LOG_ERROR("Unexpected exit code for " + ps_path + ": " + std::to_string(retcode));
-
-    return StringUtil::EndsWith(stdout_output, "\n") ? stdout_output.substr(0, stdout_output.length() - 1) : stdout_output;
+    else
+        return StringUtil::EndsWith(stdout_output, "\n") ? stdout_output.substr(0, stdout_output.length() - 1) : stdout_output;
 }
 
 

--- a/cpp/lib/src/SystemdUtil.cc
+++ b/cpp/lib/src/SystemdUtil.cc
@@ -30,8 +30,11 @@ const std::string SYSTEMD_SERVICE_DIRECTORY("/etc/systemd/system/");
 
 
 bool SystemdUtil::IsAvailable() {
-    static const bool is_available(ExecUtil::GetOriginalCommandNameFromPID(1) == "systemd");
-    return is_available;
+    // Docker: systemd not running at all (+ not installed)
+    // CentOS: systemd running with pid 1
+    // Ubuntu: systemd running with random pid
+    static const std::unordered_set<unsigned> systemd_pids(ExecUtil::FindActivePrograms("systemd"));
+    return systemd_pids.size() > 0;
 }
 
 

--- a/cpp/lib/src/SystemdUtil.cc
+++ b/cpp/lib/src/SystemdUtil.cc
@@ -30,11 +30,8 @@ const std::string SYSTEMD_SERVICE_DIRECTORY("/etc/systemd/system/");
 
 
 bool SystemdUtil::IsAvailable() {
-    // Docker: systemd not running at all (+ not installed)
-    // CentOS: systemd running with pid 1
-    // Ubuntu: systemd running with random pid
-    static const std::unordered_set<unsigned> systemd_pids(ExecUtil::FindActivePrograms("systemd"));
-    return systemd_pids.size() > 0;
+    static const bool is_available(ExecUtil::GetOriginalCommandNameFromPID(1) == "systemd");
+    return is_available;
 }
 
 


### PR DESCRIPTION
Old version also didnt't work under CentOS, because original command name is not "systemd" but something like "/usr/lib/systemd/systemd --switched"