### PR TITLE
zeder_to_zotero_importer: zeder_newly_synced_entry

### DIFF
--- a/cpp/lib/include/ZoteroHarvesterConfig.h
+++ b/cpp/lib/include/ZoteroHarvesterConfig.h
@@ -125,6 +125,7 @@ struct JournalParams {
         NAME,       // not an actual INI key; placeholder for the journal name (name of the INI section)
         ZEDER_ID,
         ZEDER_MODIFIED_TIME,
+        ZEDER_NEWLY_SYNCED_ENTRY,
         GROUP,
         ENTRY_POINT_URL,
         HARVESTER_OPERATION,
@@ -182,6 +183,7 @@ struct JournalParams {
         std::map<std::string, std::unique_ptr<ThreadSafeRegexMatcher>> fields_to_remove_;
         std::map<std::string, std::unique_ptr<ThreadSafeRegexMatcher>> exclusion_filters_;
     } marc_metadata_params_;
+    bool zeder_newly_synced_entry_;
 public:
     JournalParams(const GlobalParams &global_params);
     JournalParams(const IniFile::Section &journal_section, const GlobalParams &global_params);

--- a/cpp/lib/src/ZoteroHarvesterConfig.cc
+++ b/cpp/lib/src/ZoteroHarvesterConfig.cc
@@ -158,6 +158,7 @@ JournalParams::JournalParams(const GlobalParams &global_params) {
 
 JournalParams::JournalParams(const IniFile::Section &journal_section, const GlobalParams &global_params) {
     zeder_id_ = journal_section.getUnsigned(GetIniKeyString(ZEDER_ID));
+    zeder_newly_synced_entry_ = journal_section.getBool(GetIniKeyString(ZEDER_NEWLY_SYNCED_ENTRY), false);
     name_ = journal_section.getSectionName();
     group_ = journal_section.getString(GetIniKeyString(GROUP));
     entry_point_url_ = journal_section.getString(GetIniKeyString(ENTRY_POINT_URL));

--- a/cpp/lib/src/ZoteroHarvesterConfig.cc
+++ b/cpp/lib/src/ZoteroHarvesterConfig.cc
@@ -140,6 +140,7 @@ std::string GroupParams::GetIniKeyString(const IniKey ini_key) {
 
 JournalParams::JournalParams(const GlobalParams &global_params) {
     zeder_id_ = 1;
+    zeder_newly_synced_entry_ = false;
     name_ = "Default Journal";
     group_ = "Default Group";
     entry_point_url_ = "Default URL";
@@ -246,45 +247,47 @@ JournalParams::JournalParams(const IniFile::Section &journal_section, const Glob
 
 
 const std::map<JournalParams::IniKey, std::string> JournalParams::KEY_TO_STRING_MAP {
-    { ZEDER_ID,               "zeder_id"                  },
-    { ZEDER_MODIFIED_TIME,    "zeder_modified_time"       },
-    { GROUP,                  "zotero_group"              },
-    { ENTRY_POINT_URL,        "zotero_url"                },
-    { HARVESTER_OPERATION,    "zotero_type"               },
-    { UPLOAD_OPERATION,       "zotero_delivery_mode"      },
-    { ONLINE_PPN,             "online_ppn"                },
-    { PRINT_PPN,              "print_ppn"                 },
-    { ONLINE_ISSN,            "online_issn"               },
-    { PRINT_ISSN,             "print_issn"                },
-    { STRPTIME_FORMAT_STRING, "zotero_strptime_format"    },
-    { UPDATE_WINDOW,          "zotero_update_window"      },
-    { REVIEW_REGEX,           "zotero_review_regex"       },
-    { EXPECTED_LANGUAGES,     "zotero_expected_languages" },
-    { SSGN,                   "zotero_ssgn"               },
-    { CRAWL_MAX_DEPTH,        "zotero_max_crawl_depth"    },
-    { CRAWL_EXTRACTION_REGEX, "zotero_extraction_regex"   },
-    { CRAWL_URL_REGEX,        "zotero_crawl_url_regex"    },
+    { ZEDER_ID,                 "zeder_id"                  },
+    { ZEDER_MODIFIED_TIME,      "zeder_modified_time"       },
+    { ZEDER_NEWLY_SYNCED_ENTRY, "zeder_newly_synced_entry"  },
+    { GROUP,                    "zotero_group"              },
+    { ENTRY_POINT_URL,          "zotero_url"                },
+    { HARVESTER_OPERATION,      "zotero_type"               },
+    { UPLOAD_OPERATION,         "zotero_delivery_mode"      },
+    { ONLINE_PPN,               "online_ppn"                },
+    { PRINT_PPN,                "print_ppn"                 },
+    { ONLINE_ISSN,              "online_issn"               },
+    { PRINT_ISSN,               "print_issn"                },
+    { STRPTIME_FORMAT_STRING,   "zotero_strptime_format"    },
+    { UPDATE_WINDOW,            "zotero_update_window"      },
+    { REVIEW_REGEX,             "zotero_review_regex"       },
+    { EXPECTED_LANGUAGES,       "zotero_expected_languages" },
+    { SSGN,                     "zotero_ssgn"               },
+    { CRAWL_MAX_DEPTH,          "zotero_max_crawl_depth"    },
+    { CRAWL_EXTRACTION_REGEX,   "zotero_extraction_regex"   },
+    { CRAWL_URL_REGEX,          "zotero_crawl_url_regex"    },
 };
 
 const std::map<std::string, JournalParams::IniKey> JournalParams::STRING_TO_KEY_MAP {
-    { "zeder_id",                  ZEDER_ID               },
-    { "zeder_modified_time",       ZEDER_MODIFIED_TIME    },
-    { "zotero_group",              GROUP                  },
-    { "zotero_url",                ENTRY_POINT_URL        },
-    { "zotero_type",               HARVESTER_OPERATION    },
-    { "zotero_delivery_mode",      UPLOAD_OPERATION       },
-    { "online_ppn",                ONLINE_PPN             },
-    { "print_ppn",                 PRINT_PPN              },
-    { "online_issn",               ONLINE_ISSN            },
-    { "print_issn",                PRINT_ISSN             },
-    { "zotero_strptime_format",    STRPTIME_FORMAT_STRING },
-    { "zotero_update_window",      UPDATE_WINDOW          },
-    { "zotero_review_regex",       REVIEW_REGEX           },
-    { "zotero_expected_languages", EXPECTED_LANGUAGES     },
-    { "zotero_ssgn",               SSGN                   },
-    { "zotero_max_crawl_depth",    CRAWL_MAX_DEPTH        },
-    { "zotero_extraction_regex",   CRAWL_EXTRACTION_REGEX },
-    { "zotero_crawl_url_regex",    CRAWL_URL_REGEX        },
+    { "zeder_id",                  ZEDER_ID                 },
+    { "zeder_modified_time",       ZEDER_MODIFIED_TIME      },
+    { "zeder_newly_synced_entry",  ZEDER_NEWLY_SYNCED_ENTRY },
+    { "zotero_group",              GROUP                    },
+    { "zotero_url",                ENTRY_POINT_URL          },
+    { "zotero_type",               HARVESTER_OPERATION      },
+    { "zotero_delivery_mode",      UPLOAD_OPERATION         },
+    { "online_ppn",                ONLINE_PPN               },
+    { "print_ppn",                 PRINT_PPN                },
+    { "online_issn",               ONLINE_ISSN              },
+    { "print_issn",                PRINT_ISSN               },
+    { "zotero_strptime_format",    STRPTIME_FORMAT_STRING   },
+    { "zotero_update_window",      UPDATE_WINDOW            },
+    { "zotero_review_regex",       REVIEW_REGEX             },
+    { "zotero_expected_languages", EXPECTED_LANGUAGES       },
+    { "zotero_ssgn",               SSGN                     },
+    { "zotero_max_crawl_depth",    CRAWL_MAX_DEPTH          },
+    { "zotero_extraction_regex",   CRAWL_EXTRACTION_REGEX   },
+    { "zotero_crawl_url_regex",    CRAWL_URL_REGEX          },
 };
 
 

--- a/cpp/zeder_to_zotero_importer.cc
+++ b/cpp/zeder_to_zotero_importer.cc
@@ -292,7 +292,7 @@ unsigned ImportZederEntries(const Zeder::EntryCollection &zeder_entries, Harvest
         bool new_section(false);
         if (existing_journal_section == nullptr) {
             existing_journal_section = harvester_config->addNewConfigSection(title);
-            existing_journal_section->insert("newly_synced_entry", "true");
+            existing_journal_section->insert(Config::JournalParams::GetIniKeyString(Config::JournalParams::ZEDER_NEWLY_SYNCED_ENTRY), "true");
             new_section = true;
         }
 

--- a/cpp/zeder_to_zotero_importer.cc
+++ b/cpp/zeder_to_zotero_importer.cc
@@ -48,7 +48,8 @@ using namespace ZoteroHarvester;
             "\t                                Special-case for updating: Use '*' to update all entries found in the config that belong to the Zeder flavour\n"
             "\tfields_to_update                Comma-separated list of the following fields to update: \n"
             "\t                                \tONLINE_PPN, PRINT_PPN, ONLINE_ISSN, PRINT_ISSN, EXPECTED_LANGUAGES, ENTRY_POINT_URL, UPLOAD_OPERATION, UPDATE_WINDOW, SSGN.\n"
-            "\t                                Ignored when importing entries (all importable fields will be imported).\n\n");
+            "\t                                Ignored when importing entries (all importable fields will be imported).\n"
+            "\t                                If mode is IMPORT and zeder_ids is '*', new journals will only be added if \"prodf\" is \"zota\" or \"zotat\".\n\n");
 }
 
 
@@ -104,8 +105,7 @@ void ParseCommandLineArgs(int * const argc, char *** const argv, CommandLineArgs
         StringUtil::SplitThenTrimWhite(zeder_id_list, ',', &buffer);
         for (const auto &id_str : buffer)
             commandline_args->zeder_ids_.emplace(StringUtil::ToUnsigned(id_str));
-    } else if (commandline_args->mode_ == CommandLineArgs::Mode::IMPORT)
-        LOG_ERROR("cannot import all Zeder entries at once");
+    }
 
     if (commandline_args->mode_ == CommandLineArgs::Mode::IMPORT)
         return;
@@ -172,6 +172,7 @@ public:
     IniFile::Section *lookupConfig(const unsigned zeder_id, const Zeder::Flavour zeder_flavour) const;
     Config::JournalParams *lookupJournalParams(const unsigned zeder_id, const Zeder::Flavour zeder_flavour) const;
     IniFile::Section *addNewConfigSection(const std::string &section_name);
+    inline bool sectionIsDefined(const std::string &section_name) { return config_file_->sectionIsDefined(section_name); }
     void removeConfigSection(const std::string &section_name);
 };
 
@@ -196,7 +197,7 @@ Config::JournalParams *HarvesterConfig::lookupJournalParams(const unsigned zeder
 
 
 IniFile::Section *HarvesterConfig::addNewConfigSection(const std::string &section_name) {
-    if (config_file_->sectionIsDefined(section_name))
+    if (sectionIsDefined(section_name))
         LOG_ERROR("INI section '" + section_name + "' already exists");
 
     config_file_->appendSection(section_name);
@@ -241,13 +242,13 @@ void DetermineZederEntriesToBeDownloaded(const CommandLineArgs &commandline_args
         } else for (const auto id : commandline_args.zeder_ids_)
             entries_to_download->emplace(id);
 
+        if (entries_to_download->empty())
+            LOG_ERROR("no entries to update");
+
         break;
     default:
         break;
     }
-
-    if (entries_to_download->empty())
-        LOG_ERROR("no entries to import/update");
 }
 
 
@@ -260,7 +261,7 @@ void WriteIniEntry(IniFile::Section * const section, const std::string &name, co
 
 
 unsigned ImportZederEntries(const Zeder::EntryCollection &zeder_entries, HarvesterConfig * const harvester_config,
-                            const Zeder::Flavour zeder_flavour, const bool overwrite)
+                            const Zeder::Flavour zeder_flavour, const bool overwrite, const bool autodetect_new_datasets)
 {
     unsigned num_entries_imported(0);
     for (const auto &zeder_entry : zeder_entries) {
@@ -270,13 +271,28 @@ unsigned ImportZederEntries(const Zeder::EntryCollection &zeder_entries, Harvest
 
         auto existing_journal_section(harvester_config->lookupConfig(zeder_id, zeder_flavour));
         if (existing_journal_section != nullptr and not overwrite) {
-            LOG_WARNING("couldn't import Zeder entry " + std::to_string(zeder_id) + " (" + title + "): already exists");
+            if (not autodetect_new_datasets) {
+                LOG_WARNING("couldn't import Zeder entry " + std::to_string(zeder_id) + " (" + title + "): already exists");
+                continue;
+            } else {
+                LOG_INFO("Skipping Zeder entry " + std::to_string(zeder_id) + " (" + title + "): already exists");
+                continue;
+            }
+        } else if (existing_journal_section == nullptr and harvester_config->sectionIsDefined(title)) {
+            LOG_WARNING("couldn't import Zeder entry " + std::to_string(zeder_id) + " (" + title + "): already exists with different zeder id");
             continue;
+        } else if (existing_journal_section == nullptr and autodetect_new_datasets) {
+            const std::string prodf(zeder_entry.getAttribute("prodf", ""));
+            if (prodf != "zota" && prodf != "zotat") {
+                LOG_INFO("Skipping Zeder entry " + std::to_string(zeder_id) + " (" + title + "): prodf is neither \"zota\" nor \"zotat\"");
+                continue;
+            }
         }
 
         bool new_section(false);
         if (existing_journal_section == nullptr) {
             existing_journal_section = harvester_config->addNewConfigSection(title);
+            existing_journal_section->insert("newly_synced_entry", "true");
             new_section = true;
         }
 
@@ -332,17 +348,20 @@ unsigned ImportZederEntries(const Zeder::EntryCollection &zeder_entries, Harvest
                 if (skip_entry) {
                     if (new_section)
                         harvester_config->removeConfigSection(title);
-                    continue;
+                    goto next_entry;
                 }
             }
 
             if (not ini_val_str.empty()) {
+                LOG_DEBUG("\t" + ini_key_str + ": '" + ini_val_str + "'");
                 WriteIniEntry(existing_journal_section, ini_key_str, ini_val_str);
-                LOG_INFO("\t" + ini_key_str + ": '" + ini_val_str + "'");
             }
         }
 
         ++num_entries_imported;
+
+        next_entry:
+           ;// intentionally empty, continue outer for-loop
     }
 
     return num_entries_imported;
@@ -413,7 +432,8 @@ int Main(int argc, char *argv[]) {
     switch (commandline_args.mode_) {
     case CommandLineArgs::Mode::IMPORT: {
         const auto num_imported(ImportZederEntries(downloaded_entries, &harvester_config,
-                                commandline_args.zeder_flavour_, commandline_args.overwrite_on_import_));
+                                commandline_args.zeder_flavour_, commandline_args.overwrite_on_import_,
+                                /*autodetect_new_datasets = */ entries_to_download.empty()));
         LOG_INFO("Imported " + std::to_string(num_imported) + " Zeder entries");
         break;
     }

--- a/cpp/zeder_to_zotero_importer.cc
+++ b/cpp/zeder_to_zotero_importer.cc
@@ -271,13 +271,11 @@ unsigned ImportZederEntries(const Zeder::EntryCollection &zeder_entries, Harvest
 
         auto existing_journal_section(harvester_config->lookupConfig(zeder_id, zeder_flavour));
         if (existing_journal_section != nullptr and not overwrite) {
-            if (not autodetect_new_datasets) {
-                LOG_WARNING("couldn't import Zeder entry " + std::to_string(zeder_id) + " (" + title + "): already exists");
-                continue;
-            } else {
+            if (autodetect_new_datasets)
                 LOG_INFO("Skipping Zeder entry " + std::to_string(zeder_id) + " (" + title + "): already exists");
-                continue;
-            }
+            else
+                LOG_WARNING("couldn't import Zeder entry " + std::to_string(zeder_id) + " (" + title + "): already exists");
+            continue;
         } else if (existing_journal_section == nullptr and harvester_config->sectionIsDefined(title)) {
             LOG_WARNING("couldn't import Zeder entry " + std::to_string(zeder_id) + " (" + title + "): already exists with different zeder id");
             continue;

--- a/cpp/zotero_harvester.cc
+++ b/cpp/zotero_harvester.cc
@@ -1,7 +1,7 @@
 /** \brief Tool to automatically download metadata from online sources by leveraging Zotero
  *  \author Madeeswaran Kannan
  *
- *  \copyright 2019 Universitätsbibliothek Tübingen.  All rights reserved.
+ *  \copyright 2019,2020 Universitätsbibliothek Tübingen.  All rights reserved.
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
@@ -57,6 +57,7 @@ using namespace ZoteroHarvester;
               << "\t\tUPLOAD - Only those journals that have the specified upload operation (either LIVE or TEST) set will be processed.\n"
               << "\t\tURL - Only the specified URL is processed as a DIRECT harvester operation. An optional journal name can be provided as a second argument to associate the URL with it (reqd. for config overrides)\n"
               << "\t\tJOURNAL - If no arguments are provided, all journals are processed. Otherwise, only the specified journals are processed.\n"
+              << "\t\t          If mode is UPLOAD or JOURNAL (without specified journals), journals marked as \"" + Config::JournalParams::GetIniKeyString(Config::JournalParams::ZEDER_NEWLY_SYNCED_ENTRY) + "\" will be ignored."
               << "\n";
     std::exit(EXIT_FAILURE);
 }
@@ -635,6 +636,12 @@ int Main(int argc, char *argv[]) {
                 and not commandline_args.selected_journals_.empty()
                 and commandline_args.selected_journals_.find(journal->name_) == commandline_args.selected_journals_.end())
             {
+                continue;
+            }
+
+            if (commandline_args.selected_journals_.empty() and journal->zeder_newly_synced_entry_ == true) {
+                LOG_INFO("Skipping journal \"" + journal->name_ + "\""
+                         " (" + Config::JournalParams::GetIniKeyString(Config::JournalParams::ZEDER_NEWLY_SYNCED_ENTRY) + ")");
                 continue;
             }
 


### PR DESCRIPTION
ToDo before enabling cronjob:
- rename "newly_synced_entry"? (e.g. "newly_imported_entry")
- add documentation for "newly_synced_entry" to zotero_harvester.conf
- prevent automatic delivery of entries marked as "newly_synced_entry"