### PR TITLE
zotaut: Changes to automatic language detection (+performance settings)

### DIFF
--- a/cpp/cgi_progs/zotero_cgi.cc
+++ b/cpp/cgi_progs/zotero_cgi.cc
@@ -529,9 +529,9 @@ void ProcessShowDownloadedAction(const std::multimap<std::string, std::string> &
     for (const auto &entry : entries) {
         const std::string escaped_id(HtmlUtil::HtmlEscape(std::to_string(entry.id_)));
         const std::string link("<a href=\"" + entry.url_ + "\" target=\"_blank\">" + entry.url_  + "</a>");
-        if (not ids.empty() and ids.back() == escaped_id) {
+        if (not ids.empty() and ids.back() == escaped_id)
             links.back() += "<br>" + link;
-        } else {
+        else {
             ids.emplace_back(escaped_id);
             delivered_datetimes.emplace_back(HtmlUtil::HtmlEscape(entry.delivered_at_str_));
             titles.emplace_back(HtmlUtil::HtmlEscape(entry.main_title_));

--- a/cpp/cgi_progs/zotero_cgi.cc
+++ b/cpp/cgi_progs/zotero_cgi.cc
@@ -521,26 +521,32 @@ void ProcessShowDownloadedAction(const std::multimap<std::string, std::string> &
     std::vector<std::string> delivered_datetimes;
     std::vector<std::string> titles;
     std::vector<std::string> hashes;
-    std::vector<std::string> urls;
+    std::vector<std::string> links;
     std::vector<std::string> delivery_states;
     std::vector<std::string> error_messages;
 
     const auto entries(upload_tracker->getEntriesByZederIdAndFlavour(StringUtil::ToUnsigned(zeder_id), zeder_flavour));
     for (const auto &entry : entries) {
-        ids.emplace_back(HtmlUtil::HtmlEscape(std::to_string(entry.id_)));
-        delivered_datetimes.emplace_back(HtmlUtil::HtmlEscape(entry.delivered_at_str_));
-        titles.emplace_back(HtmlUtil::HtmlEscape(entry.main_title_));
-        hashes.emplace_back(HtmlUtil::HtmlEscape(entry.hash_));
-        urls.emplace_back(entry.url_);
-        delivery_states.emplace_back(HtmlUtil::HtmlEscape(ZoteroHarvester::Util::UploadTracker::DELIVERY_STATE_TO_STRING_MAP.at(entry.delivery_state_)));
-        error_messages.emplace_back(HtmlUtil::HtmlEscape(entry.error_message_));
+        const std::string escaped_id(HtmlUtil::HtmlEscape(std::to_string(entry.id_)));
+        const std::string link("<a href=\"" + entry.url_ + "\" target=\"_blank\">" + entry.url_  + "</a>");
+        if (not ids.empty() and ids.back() == escaped_id) {
+            links.back() += "<br>" + link;
+        } else {
+            ids.emplace_back(escaped_id);
+            delivered_datetimes.emplace_back(HtmlUtil::HtmlEscape(entry.delivered_at_str_));
+            titles.emplace_back(HtmlUtil::HtmlEscape(entry.main_title_));
+            hashes.emplace_back(HtmlUtil::HtmlEscape(entry.hash_));
+            links.emplace_back(link);
+            delivery_states.emplace_back(HtmlUtil::HtmlEscape(ZoteroHarvester::Util::UploadTracker::DELIVERY_STATE_TO_STRING_MAP.at(entry.delivery_state_)));
+            error_messages.emplace_back(HtmlUtil::HtmlEscape(entry.error_message_));
+        }
     }
 
     names_to_values_map.insertArray("ids", ids);
     names_to_values_map.insertArray("delivered_datetimes", delivered_datetimes);
     names_to_values_map.insertArray("titles", titles);
     names_to_values_map.insertArray("hashes", hashes);
-    names_to_values_map.insertArray("urls", urls);
+    names_to_values_map.insertArray("links", links);
     names_to_values_map.insertArray("delivery_states", delivery_states);
     names_to_values_map.insertArray("error_messages", error_messages);
 

--- a/cpp/data/zotero_cgi/delivered.html
+++ b/cpp/data/zotero_cgi/delivered.html
@@ -9,33 +9,37 @@
         <h1>Zotero Harvesting</h1>
         <h2>Delivered records for Zeder ID {zeder_id}</h2>
         <p><a href="?action=show_qa&zeder_id={zeder_id}&zeder_instance={zeder_instance}">Show QA settings</a></p>
-        <table border="1">
-            <tr>
-                <th>delivered at</th>
-                <th>main title</th>
-                <th>hash</th>
-                <th>url</th>
-                <th>delivery state</th>
-                <th>actions</th>
-            </tr>
-            {LOOP ids,delivered_datetimes,titles,hashes,urls,delivery_states,error_messages}
+        <table style="border-collapse: collapse;" cellpadding="5">
+            <thead>
                 <tr>
-                    <td>{delivered_datetimes}</td>
-                    <td>{titles}</td>
-                    <td>{hashes}</td>
-                    <td><a href="{urls}" target="_blank">{urls}</a></td>
-                    <td align="center" style="vertical-align: middle;">
-                        {IF delivery_states == "automatic"}<span class="dot" style="background-color: green;" title="This record has been delivered automatically."></span>{ENDIF}
-                        {IF delivery_states == "manual"}<span class="dot" style="background-color: turquoise;" title="This record has been delivered manually and will no longer be harvested automatically."></span>{ENDIF}
-                        {IF delivery_states == "error"}<span class="dot" style="background-color: yellow;" title="An error has occurred while trying to deliver this record:&#013;{error_messages}"></span>{ENDIF}
-                    </td>
-                    <td>
-                        {IF delivery_states == "error"}
-                            <a href="?action=show_downloaded&zeder_id={zeder_id}&group={group}&set_manually_delivered={ids}" onclick="return confirm('Are you sure? This record and all its URLs will no longer be processed automatically.')">Deliver manually</a>
-                        {ENDIF}
-                    </td>
+                    <th>delivered at</th>
+                    <th>main title</th>
+                    <th>hash</th>
+                    <th>url</th>
+                    <th>delivery state</th>
+                    <th>actions</th>
                 </tr>
-            {ENDLOOP}
+            </thead>
+            <tbody>
+                {LOOP ids,delivered_datetimes,titles,hashes,links,delivery_states,error_messages}
+                    <tr>
+                        <td>{delivered_datetimes}</td>
+                        <td>{titles}</td>
+                        <td>{hashes}</td>
+                        <td>{links}</td>
+                        <td align="center" style="vertical-align: middle;">
+                            {IF delivery_states == "automatic"}<span class="dot" style="background-color: green;" title="This record has been delivered automatically."></span>{ENDIF}
+                            {IF delivery_states == "manual"}<span class="dot" style="background-color: turquoise;" title="This record has been delivered manually and will no longer be harvested automatically."></span>{ENDIF}
+                            {IF delivery_states == "error"}<span class="dot" style="background-color: yellow;" title="An error has occurred while trying to deliver this record:&#013;{error_messages}"></span>{ENDIF}
+                        </td>
+                        <td>
+                            {IF delivery_states == "error"}
+                                <a href="?action=show_downloaded&zeder_id={zeder_id}&group={group}&set_manually_delivered={ids}" onclick="return confirm('Are you sure? This record and all its URLs will no longer be processed automatically.')">Deliver manually</a>
+                            {ENDIF}
+                        </td>
+                    </tr>
+                {ENDLOOP}
+            </tbody>
         </table>
     </body>
 </html>

--- a/cpp/data/zotero_cgi/style.css
+++ b/cpp/data/zotero_cgi/style.css
@@ -3,6 +3,11 @@ body {
     color: #333;
 }
 
+th {
+    border: 1px solid black;
+    border-collapse: collapse;
+}
+
 td {
     border: 1px solid black;
     border-collapse: collapse;

--- a/cpp/lib/include/ZoteroHarvesterConfig.h
+++ b/cpp/lib/include/ZoteroHarvesterConfig.h
@@ -189,11 +189,10 @@ private:
 
 
 struct LanguageParams {
-    std::set<std::string> expected_languages_ = {"eng"};
+    std::set<std::string> expected_languages_ = {};
     std::string source_text_fields_ = "title";
-    bool force_automatic_language_detection_ = false;
 public:
-    void reset() { expected_languages_ = {"eng"}; source_text_fields_ = "title"; force_automatic_language_detection_ = false; }
+    void reset() { expected_languages_ = {}; source_text_fields_ = "title"; }
 };
 
 

--- a/cpp/lib/include/ZoteroHarvesterConfig.h
+++ b/cpp/lib/include/ZoteroHarvesterConfig.h
@@ -189,10 +189,10 @@ private:
 
 
 struct LanguageParams {
-    std::set<std::string> expected_languages_ = {};
+    std::set<std::string> expected_languages_;
     std::string source_text_fields_ = "title";
 public:
-    void reset() { expected_languages_ = {}; source_text_fields_ = "title"; }
+    void reset() { expected_languages_.clear(); source_text_fields_ = "title"; }
 };
 
 

--- a/cpp/lib/include/ZoteroHarvesterDownload.h
+++ b/cpp/lib/include/ZoteroHarvesterDownload.h
@@ -57,6 +57,12 @@ class DownloadManager;
 namespace DirectDownload {
 
 
+// Set to 20 empirically. Larger numbers increase the incidence of the
+// translation server bug that returns an empty/broken response.
+static constexpr unsigned MAX_CONCURRENT_TRANSLATION_SERVER_REQUESTS = 4; // Temporarily reduced in order to see if this results in fewer response codes
+                                                                          // with value 0
+
+
 enum class Operation { USE_TRANSLATION_SERVER, DIRECT_QUERY };
 
 

--- a/cpp/lib/include/ZoteroHarvesterDownload.h
+++ b/cpp/lib/include/ZoteroHarvesterDownload.h
@@ -47,6 +47,15 @@ namespace ZoteroHarvester {
 namespace Download {
 
 
+// Temporarily reduced in order to see if this results in fewer errors
+static constexpr unsigned MAX_DIRECT_DOWNLOAD_TASKLETS = 5;
+static constexpr unsigned MAX_CRAWLING_TASKLETS        = 5;
+static constexpr unsigned MAX_RSS_TASKLETS             = 5;
+// Set to 20 empirically. Larger numbers increase the incidence of the
+// translation server bug that returns an empty/broken response.
+static constexpr unsigned MAX_CONCURRENT_TRANSLATION_SERVER_REQUESTS = 15;
+
+
 class DownloadManager;
 
 
@@ -55,12 +64,6 @@ class DownloadManager;
 // and successfully retrieved metadata are cached locally to reduce the number of outbound requests.
 // Returns the remote server's response with additional extra data.
 namespace DirectDownload {
-
-
-// Set to 20 empirically. Larger numbers increase the incidence of the
-// translation server bug that returns an empty/broken response.
-static constexpr unsigned MAX_CONCURRENT_TRANSLATION_SERVER_REQUESTS = 4; // Temporarily reduced in order to see if this results in fewer response codes
-                                                                          // with value 0
 
 
 enum class Operation { USE_TRANSLATION_SERVER, DIRECT_QUERY };
@@ -350,11 +353,6 @@ private:
         DirectDownload::Operation operation_;
         std::string response_body_;
     };
-
-
-    static constexpr unsigned MAX_DIRECT_DOWNLOAD_TASKLETS = 50;
-    static constexpr unsigned MAX_CRAWLING_TASKLETS        = 50;
-    static constexpr unsigned MAX_RSS_TASKLETS             = 50;
 
 
     GlobalParams global_params_;

--- a/cpp/lib/src/ZoteroHarvesterConfig.cc
+++ b/cpp/lib/src/ZoteroHarvesterConfig.cc
@@ -227,8 +227,7 @@ JournalParams::JournalParams(const GlobalParams &global_params) {
     issn_.online_ = "Default ISSN";
     strptime_format_string_ = global_params.strptime_format_string_;
     update_window_ = 0;
-    language_params_.force_automatic_language_detection_ = false;
-    language_params_.expected_languages_.emplace("eng");
+    language_params_.expected_languages_ = {};
     crawl_params_.max_crawl_depth_ = 1;
 }
 
@@ -416,13 +415,10 @@ bool ParseExpectedLanguages(const std::string &expected_languages_string, Langua
     if (expected_languages_string.empty())
         return true;
 
+    // force? (deprecated, treat as invalid)
     std::string expected_languages(expected_languages_string);
-
-    // force?
-    if (not expected_languages_string.empty() and expected_languages[0] == '*') {
-        language_params->force_automatic_language_detection_ = true;
-        expected_languages = expected_languages.substr(1);
-    }
+    if (expected_languages[0] == '*')
+        return false;
 
     // source text fields
     const auto field_separator_pos(expected_languages.find(':'));

--- a/cpp/lib/src/ZoteroHarvesterConfig.cc
+++ b/cpp/lib/src/ZoteroHarvesterConfig.cc
@@ -227,7 +227,6 @@ JournalParams::JournalParams(const GlobalParams &global_params) {
     issn_.online_ = "Default ISSN";
     strptime_format_string_ = global_params.strptime_format_string_;
     update_window_ = 0;
-    language_params_.expected_languages_ = {};
     crawl_params_.max_crawl_depth_ = 1;
 }
 

--- a/cpp/lib/src/ZoteroHarvesterConversion.cc
+++ b/cpp/lib/src/ZoteroHarvesterConversion.cc
@@ -518,7 +518,7 @@ void DetectLanguage(MetadataRecord * const metadata_record, const Config::Journa
     // Normalize given language
     if (not Config::IsAllowedLanguage(metadata_record->language_)) {
         LOG_WARNING("Removing invalid language: " + metadata_record->language_);
-        metadata_record->language_ = "";
+        metadata_record->language_.clear();
     } else if (not Config::IsNormalizedLanguage(metadata_record->language_)) {
         const std::string normalized_language(Config::GetNormalizedLanguage(metadata_record->language_));
         LOG_DEBUG("Normalized language: " + metadata_record->language_ + " => " + normalized_language);
@@ -557,11 +557,11 @@ void DetectLanguage(MetadataRecord * const metadata_record, const Config::Journa
             LOG_INFO("Using detected language: " + detected_language);
             metadata_record->language_ = detected_language;
         } else if (detected_language == metadata_record->language_)
-            LOG_INFO("The given language has been is equal to the detected language: " + detected_language);
+            LOG_INFO("The given language is equal to the detected language: " + detected_language);
         else {
             LOG_INFO("The given language " + metadata_record->language_ +  " and the detected language " + detected_language + " are different. "
                      "No language will be set.");
-            metadata_record->language_ = "";
+            metadata_record->language_.clear();
         }
     }
 }

--- a/cpp/lib/src/ZoteroHarvesterConversion.cc
+++ b/cpp/lib/src/ZoteroHarvesterConversion.cc
@@ -466,43 +466,62 @@ void PostProcessAuthorName(std::string * const first_name, std::string * const l
 }
 
 
-void IdentifyMissingLanguage(MetadataRecord * const metadata_record, const Config::JournalParams &journal_params) {
-    const unsigned minimum_token_count(5);
-
-    if (journal_params.language_params_.expected_languages_.empty())
-        return;
-
-    if (journal_params.language_params_.expected_languages_.size() == 1) {
-        metadata_record->language_ = *journal_params.language_params_.expected_languages_.begin();
-        LOG_DEBUG("language set to default language '" + metadata_record->language_ + "'");
-        return;
+void DetectLanguage(MetadataRecord * const metadata_record, const Config::JournalParams &journal_params) {
+    // Normalize given language
+    if (not Config::IsAllowedLanguage(metadata_record->language_)) {
+        LOG_WARNING("Removing invalid language: " + metadata_record->language_);
+        metadata_record->language_ = "";
+    } else if (not Config::IsNormalizedLanguage(metadata_record->language_)) {
+        const std::string normalized_language(Config::GetNormalizedLanguage(metadata_record->language_));
+        LOG_DEBUG("Normalized language: " + metadata_record->language_ + " => " + normalized_language);
+        metadata_record->language_ = normalized_language;
     }
 
     // attempt to automatically detect the language
-    std::vector<std::string> top_languages;
-    std::string record_text;
+    if (journal_params.language_params_.expected_languages_.empty())
+        return;
 
-    if (journal_params.language_params_.source_text_fields_.empty()
-        or journal_params.language_params_.source_text_fields_ == "title")
-    {
-        record_text = metadata_record->title_;
-        // use naive tokenization to count tokens in the title
-        // additionally use abstract if we have too few tokens in the title
-        if (StringUtil::CharCount(record_text, ' ') < minimum_token_count) {
-            record_text += " " + metadata_record->abstract_note_;
-            LOG_DEBUG("too few tokens in title. applying heuristic on the abstract as well");
+    std::string detected_language;
+    if (journal_params.language_params_.expected_languages_.size() == 1)
+        detected_language = *journal_params.language_params_.expected_languages_.begin();
+    else {
+        std::vector<std::string> top_languages;
+        std::string record_text;
+        if (journal_params.language_params_.source_text_fields_.empty()
+            or journal_params.language_params_.source_text_fields_ == "title")
+        {
+            record_text = metadata_record->title_;
+            // use naive tokenization to count tokens in the title
+            // additionally use abstract if we have too few tokens in the title
+            static const unsigned minimum_token_count(5);
+            if (StringUtil::CharCount(record_text, ' ') < minimum_token_count) {
+                record_text += " " + metadata_record->abstract_note_;
+                LOG_DEBUG("too few tokens in title. applying heuristic on the abstract as well");
+            }
+        } else if (journal_params.language_params_.source_text_fields_ == "abstract")
+            record_text = metadata_record->abstract_note_;
+        else if (journal_params.language_params_.source_text_fields_ == "title+abstract")
+            record_text = metadata_record->title_ + " " + metadata_record->abstract_note_;
+        else
+            LOG_ERROR("unknown text field '" + journal_params.language_params_.source_text_fields_ + "' for language detection");
+
+        NGram::ClassifyLanguage(record_text, &top_languages, journal_params.language_params_.expected_languages_,
+                                NGram::DEFAULT_NGRAM_NUMBER_THRESHOLD);
+        detected_language = top_languages.front();
+    }
+
+    if (not detected_language.empty()) {
+        if (metadata_record->language_.empty()) {
+            LOG_INFO("Using detected language: " + detected_language);
+            metadata_record->language_ = detected_language;
+        } else if (detected_language == metadata_record->language_)
+            LOG_INFO("The given language has been is equal to the detected language: " + detected_language);
+        else {
+            LOG_INFO("The given language " + metadata_record->language_ +  " and the detected language " + detected_language + " are different. "
+                     "No language will be set.");
+            metadata_record->language_ = "";
         }
-    } else if (journal_params.language_params_.source_text_fields_ == "abstract")
-        record_text = metadata_record->abstract_note_;
-    else if (journal_params.language_params_.source_text_fields_ == "title+abstract")
-        record_text = metadata_record->title_ + " " + metadata_record->abstract_note_;
-    else
-        LOG_ERROR("unknown text field '" + journal_params.language_params_.source_text_fields_ + "' for language detection");
-
-    NGram::ClassifyLanguage(record_text, &top_languages, journal_params.language_params_.expected_languages_,
-                            NGram::DEFAULT_NGRAM_NUMBER_THRESHOLD);
-    metadata_record->language_ = top_languages.front();
-    LOG_INFO("automatically detected language to be '" + metadata_record->language_ + "'");
+    }
 }
 
 
@@ -642,24 +661,7 @@ void AugmentMetadataRecord(MetadataRecord * const metadata_record, const Convers
         }
     }
 
-    // autodetect or map language
-    bool autodetect_language(false);
-    const std::string autodetect_message("forcing automatic language detection, reason: ");
-    if (journal_params.language_params_.force_automatic_language_detection_) {
-        LOG_DEBUG(autodetect_message + "conf setting");
-        autodetect_language = true;
-    } else if (metadata_record->language_.empty()) {
-        LOG_DEBUG(autodetect_message + "empty language");
-        autodetect_language = true;
-    } else if (not Config::IsAllowedLanguage(metadata_record->language_)) {
-        LOG_DEBUG(autodetect_message + "invalid language \"" + metadata_record->language_ + "\"");
-        autodetect_language = true;
-    }
-
-    if (autodetect_language)
-        IdentifyMissingLanguage(metadata_record, journal_params);
-    else
-        metadata_record->language_ = Config::GetNormalizedLanguage(metadata_record->language_);
+    DetectLanguage(metadata_record, journal_params);
 
     // fill-in license and SSG values
     if (journal_params.license_ == "LF")

--- a/cpp/lib/src/ZoteroHarvesterConversion.cc
+++ b/cpp/lib/src/ZoteroHarvesterConversion.cc
@@ -539,13 +539,6 @@ void DetectLanguage(MetadataRecord * const metadata_record, const Config::Journa
             or journal_params.language_params_.source_text_fields_ == "title")
         {
             record_text = metadata_record->title_;
-            // use naive tokenization to count tokens in the title
-            // additionally use abstract if we have too few tokens in the title
-            static const unsigned minimum_token_count(5);
-            if (StringUtil::CharCount(record_text, ' ') < minimum_token_count) {
-                record_text += " " + metadata_record->abstract_note_;
-                LOG_DEBUG("too few tokens in title. applying heuristic on the abstract as well");
-            }
         } else if (journal_params.language_params_.source_text_fields_ == "abstract")
             record_text = metadata_record->abstract_note_;
         else if (journal_params.language_params_.source_text_fields_ == "title+abstract")

--- a/cpp/lib/src/ZoteroHarvesterDownload.cc
+++ b/cpp/lib/src/ZoteroHarvesterDownload.cc
@@ -34,10 +34,6 @@ namespace Download {
 namespace DirectDownload {
 
 
-// Set to 20 empirically. Larger numbers increase the incidence of the
-// translation server bug that returns an empty/broken response.
-constexpr unsigned MAX_CONCURRENT_TRANSLATION_SERVER_REQUESTS = 4; // Temporarily reduced in order to see if this results in fewer response codes
-                                                                   // with value 0
 ThreadUtil::Semaphore translation_server_request_semaphore(MAX_CONCURRENT_TRANSLATION_SERVER_REQUESTS);
 
 

--- a/cpp/lib/src/ZoteroHarvesterDownload.cc
+++ b/cpp/lib/src/ZoteroHarvesterDownload.cc
@@ -60,16 +60,17 @@ void PostToTranslationServer(const Url &translation_server_url, const unsigned t
     downloader_params.post_data_ = request_body;
 
     try {
+        LOG_DEBUG("Sending request to translation server: " + request_body);
         const Url endpoint_url(translation_server_url.toString() + "/web");
         Downloader downloader(endpoint_url, downloader_params, time_limit);
         if (downloader.anErrorOccurred()) {
             *response_code = downloader.getLastErrorCode();
             *error_message = downloader.getLastErrorMessage();
-
             LOG_WARNING("failed to fetch response from the translation server! error: " + *error_message);
         } else {
             *response_body = downloader.getMessageBody();
             *response_code = downloader.getResponseCode();
+            LOG_DEBUG("Successful response from translation server for request: " + request_body + ", response code: " + std::to_string(downloader.getResponseCode()));
         }
     } catch (std::runtime_error &err) {
         LOG_WARNING("failed to fetch response from the translation server! runtime error: " + std::string(err.what()));
@@ -85,10 +86,10 @@ void QueryRemoteUrl(const std::string &url, const unsigned time_limit, const boo
                     const std::string &user_agent, std::string * const response_header, std::string * const response_body,
                     unsigned * response_code, std::string * const error_message)
 {
+    LOG_DEBUG("Querying remote URL: " + url);
     Downloader::Params downloader_params;
     downloader_params.user_agent_ = user_agent;
     downloader_params.honour_robots_dot_txt_ = not ignore_robots_dot_txt;
-
     Downloader downloader(url, downloader_params, time_limit);
     if (downloader.anErrorOccurred()) {
         *response_code = 0;
@@ -98,6 +99,7 @@ void QueryRemoteUrl(const std::string &url, const unsigned time_limit, const boo
         return;
     }
 
+    LOG_DEBUG("Query for remote URL successful: " + url);
     *response_body = downloader.getMessageBody();
     *response_header = downloader.getMessageHeader();
     *response_code = downloader.getResponseCode();

--- a/cpp/lib/src/ZoteroHarvesterUtil.cc
+++ b/cpp/lib/src/ZoteroHarvesterUtil.cc
@@ -571,7 +571,7 @@ std::vector<UploadTracker::Entry> UploadTracker::getEntriesByZederIdAndFlavour(c
                              "LEFT JOIN zeder_journals AS zj ON dmr.zeder_journal_id = zj.id "
                              "WHERE zj.zeder_id=" + db_connection.escapeString(std::to_string(zeder_id)) + " "
                              "AND zj.zeder_instance=" + db_connection.escapeAndQuoteString(zeder_instance) + " "
-                             "ORDER BY dmr.delivered_at ASC");
+                             "ORDER BY dmr.delivered_at, dmr.id ASC");
 
     return GetEntriesFromLastResultSet(&db_connection);
 }


### PR DESCRIPTION
- remove * from zotero_expected_languages in zotero_harvester.conf directly after merging this
- also tell socheres to remove * from Zeder