### PR TITLE
rss_aggregator: Limit item description to 500 characters

### DIFF
--- a/cpp/lib/include/HtmlUtil.h
+++ b/cpp/lib/include/HtmlUtil.h
@@ -108,7 +108,7 @@ std::string StripHtmlTags(const std::string &text_with_optional_tags, const bool
 
 
 /** \brief Shorten a text but keep HTML structure. */
-std::string ShortenText(const std::string &html_document, const unsigned max_length);
+std::string ShortenText(const std::string &html_document, const size_t max_length);
 
 
 } // namespace HtmlUtil

--- a/cpp/lib/include/HtmlUtil.h
+++ b/cpp/lib/include/HtmlUtil.h
@@ -107,4 +107,8 @@ size_t ExtractAllLinks(const std::string &html_document, std::vector<std::string
 std::string StripHtmlTags(const std::string &text_with_optional_tags, const bool replace_entities = true);
 
 
+/** \brief Shorten a text but keep HTML structure. */
+std::string ShortenText(const std::string &html_document, const unsigned max_length);
+
+
 } // namespace HtmlUtil

--- a/cpp/lib/src/HtmlUtil.cc
+++ b/cpp/lib/src/HtmlUtil.cc
@@ -1019,4 +1019,32 @@ std::string StripHtmlTags(const std::string &text_with_optional_tags, const bool
 }
 
 
+std::string ShortenText(const std::string &html_text, const unsigned max_length) {
+    std::string shortened_text;
+    shortened_text.reserve(html_text.size());
+
+    bool in_tag(false);
+    unsigned length(0);
+
+    static const std::string placeholder("...");
+    unsigned max_length_without_placeholder(max_length - placeholder.length());
+    for (auto ch(html_text.cbegin()); ch != html_text.cend(); ++ch) {
+        if (*ch == '<')
+            in_tag = true;
+        else if (*ch == '>')
+            in_tag = false;
+        else if (not in_tag and *ch != '\r' and *ch != '\n' and *ch != '\t') {
+            ++length;
+            if (length >= max_length_without_placeholder) {
+                if (length == max_length_without_placeholder)
+                    shortened_text += placeholder;
+                continue;
+            }
+        }
+        shortened_text += *ch;
+    }
+    return shortened_text;
+}
+
+
 } // namespace HtmlUtil

--- a/cpp/lib/src/HtmlUtil.cc
+++ b/cpp/lib/src/HtmlUtil.cc
@@ -1019,12 +1019,12 @@ std::string StripHtmlTags(const std::string &text_with_optional_tags, const bool
 }
 
 
-std::string ShortenText(const std::string &html_text, const unsigned max_length) {
+std::string ShortenText(const std::string &html_text, const size_t max_length) {
     std::string shortened_text;
     shortened_text.reserve(html_text.size());
 
     bool in_tag(false);
-    unsigned length(0);
+    size_t length(0);
 
     static const std::string placeholder("...");
     unsigned max_length_without_placeholder(max_length - placeholder.length());

--- a/cpp/lib/src/HtmlUtil.cc
+++ b/cpp/lib/src/HtmlUtil.cc
@@ -1034,7 +1034,9 @@ std::string ShortenText(const std::string &html_text, const size_t max_length) {
         else if (ch == '>')
             in_tag = false;
         else if (not in_tag and ch != '\r' and ch != '\n' and ch != '\t') {
-            ++length;
+            if (not TextUtil::IsUFT8ContinuationByte(ch))
+                ++length;
+
             if (length >= max_length_without_placeholder) {
                 if (length == max_length_without_placeholder)
                     shortened_text += placeholder;

--- a/cpp/lib/src/HtmlUtil.cc
+++ b/cpp/lib/src/HtmlUtil.cc
@@ -1028,12 +1028,12 @@ std::string ShortenText(const std::string &html_text, const size_t max_length) {
 
     static const std::string placeholder("...");
     unsigned max_length_without_placeholder(max_length - placeholder.length());
-    for (auto ch(html_text.cbegin()); ch != html_text.cend(); ++ch) {
-        if (*ch == '<')
+    for (const auto ch : html_text) {
+        if (ch == '<')
             in_tag = true;
-        else if (*ch == '>')
+        else if (ch == '>')
             in_tag = false;
-        else if (not in_tag and *ch != '\r' and *ch != '\n' and *ch != '\t') {
+        else if (not in_tag and ch != '\r' and ch != '\n' and ch != '\t') {
             ++length;
             if (length >= max_length_without_placeholder) {
                 if (length == max_length_without_placeholder)
@@ -1041,7 +1041,7 @@ std::string ShortenText(const std::string &html_text, const size_t max_length) {
                 continue;
             }
         }
-        shortened_text += *ch;
+        shortened_text += ch;
     }
     return shortened_text;
 }

--- a/cpp/rss_aggregator.cc
+++ b/cpp/rss_aggregator.cc
@@ -29,6 +29,7 @@
 #include "Downloader.h"
 #include "EmailSender.h"
 #include "FileUtil.h"
+#include "HtmlUtil.h"
 #include "IniFile.h"
 #include "RegexMatcher.h"
 #include "SqlUtil.h"
@@ -81,7 +82,7 @@ void WriteRSSFeedXMLOutput(const IniFile &ini_file, std::vector<HarvestedRSSItem
 
         xml_writer->writeTagsWithData("link", harvested_item.item_.getLink());
 
-        const auto description(harvested_item.item_.getDescription());
+        const auto description(HtmlUtil::ShortenText(harvested_item.item_.getDescription(), /*max_length = */500));
         if (not description.empty())
             xml_writer->writeTagsWithData("description", description);
 


### PR DESCRIPTION
... not sure if it is necessary to improve the algorithm (e.g. skip entities and multibyte characters)