### PR TITLE
TranslationUtil.cc: Swap values for msa+may

### DIFF
--- a/cpp/lib/src/TranslationUtil.cc
+++ b/cpp/lib/src/TranslationUtil.cc
@@ -161,7 +161,7 @@ static std::map<std::string, std::string> german_to_3or4letter_english_codes {
     { "fra", "fre" },
     { "gre", "gre" },
     { "ita", "ita" },
-    { "may", "msa" },
+    { "msa", "may" },
     { "nld", "dut" },
     { "por", "por" },
     { "rum", "ron" },


### PR DESCRIPTION
Columns have been in the wrong order for this language, see:
https://de.wikipedia.org/wiki/Liste_der_ISO-639-1-Codes