### PR TITLE
install_centos_packages.sh: Use old composer version (1.x) to avoid compatibility problems

### DIFF
--- a/cpp/data/installer/scripts/install_centos_packages.sh
+++ b/cpp/data/installer/scripts/install_centos_packages.sh
@@ -93,7 +93,7 @@ if [[ $1 == "ixtheo" || $1 == "krimdok" ]]; then
     else
         ColorEcho "installing composer"
         wget --output-document=/tmp/composer-setup.php https://getcomposer.org/installer
-        php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
+        php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.10.19
     fi
 fi
 


### PR DESCRIPTION
Existing installations under CentOS are currently removed each time a make install is executed, because /usr/local/bin is deleted