### PR TITLE
zotaut language detection '!' and '?'

### DIFF
--- a/cpp/lib/include/ZoteroHarvesterConfig.h
+++ b/cpp/lib/include/ZoteroHarvesterConfig.h
@@ -203,10 +203,12 @@ private:
 
 
 struct LanguageParams {
+    enum Mode : unsigned { DEFAULT, FORCE_LANGUAGES, FORCE_DETECTION };
     std::set<std::string> expected_languages_;
     std::string source_text_fields_ = "title";
+    Mode mode_;
 public:
-    void reset() { expected_languages_.clear(); source_text_fields_ = "title"; }
+    void reset() { expected_languages_.clear(); source_text_fields_ = "title"; mode_ = DEFAULT; }
 };
 
 
@@ -267,7 +269,6 @@ struct JournalParams {
     MarcMetadataParams marc_metadata_params_;
     bool zeder_newly_synced_entry_;
     bool selective_evaluation_;
-    bool force_language_detection_;
 public:
     JournalParams(const GlobalParams &global_params);
     JournalParams(const IniFile::Section &journal_section, const GlobalParams &global_params);

--- a/cpp/lib/include/ZoteroHarvesterConversion.h
+++ b/cpp/lib/include/ZoteroHarvesterConversion.h
@@ -76,7 +76,7 @@ struct MetadataRecord {
     std::string pages_;
     std::string date_;
     std::string doi_;
-    std::string language_;
+    std::set<std::string> languages_;
     std::string url_;
     std::string issn_;
     std::string license_;

--- a/cpp/lib/src/ZoteroHarvesterConfig.cc
+++ b/cpp/lib/src/ZoteroHarvesterConfig.cc
@@ -259,7 +259,6 @@ JournalParams::JournalParams(const GlobalParams &global_params) {
     update_window_ = 0;
     crawl_params_.max_crawl_depth_ = 1;
     selective_evaluation_ = false;
-    force_language_detection_ = false;
 }
 
 
@@ -339,7 +338,6 @@ JournalParams::JournalParams(const IniFile::Section &journal_section, const Glob
     ssgn_ = journal_section.getString(GetIniKeyString(SSGN), "");
     license_ = journal_section.getString(GetIniKeyString(LICENSE), "");
     selective_evaluation_ = journal_section.getBool(GetIniKeyString(SELECTIVE_EVALUATION), false);
-    force_language_detection_ = journal_section.getBool(GetIniKeyString(FORCE_LANGUAGE_DETECTION), false);
 
     const auto review_regex(journal_section.getString(GetIniKeyString(REVIEW_REGEX), ""));
     if (not review_regex.empty())
@@ -348,6 +346,10 @@ JournalParams::JournalParams(const IniFile::Section &journal_section, const Glob
     const std::string expected_languages(journal_section.getString(GetIniKeyString(EXPECTED_LANGUAGES), ""));
     if (not ParseExpectedLanguages(expected_languages, &language_params_))
         LOG_ERROR("invalid setting for expected languages: \"" + expected_languages + "\"");
+
+    // for backwards compatibility:
+    if (journal_section.getBool(GetIniKeyString(FORCE_LANGUAGE_DETECTION), false) and language_params_.mode_ == LanguageParams::DEFAULT)
+        language_params_.mode_ = LanguageParams::FORCE_DETECTION;
 
     crawl_params_.max_crawl_depth_ = journal_section.getUnsigned(GetIniKeyString(CRAWL_MAX_DEPTH), 0);
     const auto extraction_regex(journal_section.getString(GetIniKeyString(CRAWL_EXTRACTION_REGEX), ""));
@@ -458,15 +460,23 @@ std::string GetNormalizedLanguage(const std::string &language) {
 
 
 bool ParseExpectedLanguages(const std::string &expected_languages_string, LanguageParams * const language_params) {
-    // Setting is optional, so empty value is allowed (use defaults)
+    // setting is optional, so empty value is allowed (use defaults)
     language_params->reset();
     if (expected_languages_string.empty())
         return true;
 
-    // force? (deprecated, treat as invalid)
+    // detect mode (* is old/deprecated)
     std::string expected_languages(expected_languages_string);
     if (expected_languages[0] == '*')
         return false;
+    else if (expected_languages[0] == '!' or expected_languages[0] == '?') {
+        if (expected_languages[0] == '!')
+            language_params->mode_ = Config::LanguageParams::FORCE_LANGUAGES;
+        else if (expected_languages[0] == '?')
+            language_params->mode_ = Config::LanguageParams::FORCE_DETECTION;
+
+        expected_languages = expected_languages.substr(1);
+    }
 
     // source text fields
     const auto field_separator_pos(expected_languages.find(':'));

--- a/cpp/lib/src/ZoteroHarvesterConversion.cc
+++ b/cpp/lib/src/ZoteroHarvesterConversion.cc
@@ -535,24 +535,19 @@ std::string TikaDetectLanguage(const std::string &record_text) {
 
 void NormalizeGivenLanguages(MetadataRecord * const metadata_record) {
     // Normalize given languages
-    // We cant remove during iteration, so we use a multipass approach
-    std::set<std::string> unallowed_languages;
-    std::set<std::string> normalized_languages;
-    for (const auto &language : metadata_record->languages_) {
-        if (not Config::IsAllowedLanguage(language)) {
+    // We cant remove during iteration, so we use a copy
+    std::set<std::string> languages(metadata_record->languages_);
+    metadata_record->languages_.clear();
+    for (const auto &language : languages) {
+        if (not Config::IsAllowedLanguage(language))
             LOG_WARNING("Removing invalid language: " + language);
-            unallowed_languages.emplace(language);
-        } else if (not Config::IsNormalizedLanguage(language)) {
+        else if (not Config::IsNormalizedLanguage(language)) {
             const std::string normalized_language(Config::GetNormalizedLanguage(language));
             LOG_INFO("Normalized language: " + language + " => " + normalized_language);
-            unallowed_languages.emplace(language);
-            normalized_languages.emplace(normalized_language);
-        }
+            metadata_record->languages_.emplace(normalized_language);
+        } else
+            metadata_record->languages_.emplace(language);
     }
-    for (const auto &language : unallowed_languages)
-        metadata_record->languages_.erase(language);
-    for (const auto &normalized_language : normalized_languages)
-        metadata_record->languages_.emplace(normalized_language);
 }
 
 

--- a/cpp/lib/src/ZoteroHarvesterConversion.cc
+++ b/cpp/lib/src/ZoteroHarvesterConversion.cc
@@ -1012,8 +1012,8 @@ void GenerateMarcRecordFromMetadataRecord(const MetadataRecord &metadata_record,
         marc_record->insertField("245", { { 'a', metadata_record.title_ } }, /* indicator 1 = */'0', /* indicator 2 = */'0');
 
     // Language
-    for (const auto &language : metadata_record.languages_)
-        marc_record->insertField("041", { { 'a', language } });
+    for (auto language(metadata_record.languages_.rbegin()); language != metadata_record.languages_.rend(); ++language)
+        marc_record->insertField("041", { { 'a', *language } });
 
     // Abstract Note
     if (not metadata_record.abstract_note_.empty())

--- a/cpp/lib/src/ZoteroHarvesterConversion.cc
+++ b/cpp/lib/src/ZoteroHarvesterConversion.cc
@@ -290,7 +290,7 @@ void ConvertZoteroItemToMetadataRecord(const std::shared_ptr<JSON::ObjectNode> &
     metadata_record->doi_ = GetStrippedHTMLStringFromJSON(zotero_item, "DOI");
     const std::string language(GetStrippedHTMLStringFromJSON(zotero_item, "language"));
     if (not language.empty())
-        metadata_record->languages_.emplace();
+        metadata_record->languages_.emplace(language);
     metadata_record->url_ = GetStrippedHTMLStringFromJSON(zotero_item, "url");
     metadata_record->issn_ = GetStrippedHTMLStringFromJSON(zotero_item, "ISSN");
 

--- a/cpp/lib/src/ZoteroHarvesterConversion.cc
+++ b/cpp/lib/src/ZoteroHarvesterConversion.cc
@@ -597,24 +597,27 @@ void AdjustLanguages(MetadataRecord * const metadata_record, const Config::Journ
     }
 
     // automatic language detection
-    std::string detected_language;
-    if (journal_params.language_params_.expected_languages_.size() == 1)
+    std::string detected_language, configured_or_detected_info;
+    if (journal_params.language_params_.expected_languages_.size() == 1) {
         detected_language = *journal_params.language_params_.expected_languages_.begin();
-    else
+        configured_or_detected_info = "single configured";
+    } else {
         detected_language = DetectLanguage(metadata_record, journal_params);
+        configured_or_detected_info = "detected";
+    }
 
     // compare language from zotero to detected language
     if (not detected_language.empty()) {
         if (journal_params.language_params_.mode_ == Config::LanguageParams::FORCE_DETECTION) {
-            LOG_INFO ("Force language detection active - using detected language: " + detected_language);
+            LOG_INFO ("Force language detection active - using " + configured_or_detected_info + " language: " + detected_language);
             metadata_record->languages_ = { detected_language };
         } else if (metadata_record->languages_.empty()) {
-            LOG_INFO("Using detected language: " + detected_language);
+            LOG_INFO("Using " + configured_or_detected_info + " language: " + detected_language);
             metadata_record->languages_.emplace(detected_language);
         } else if (*metadata_record->languages_.begin() == detected_language and metadata_record->languages_.size() == 1)
-            LOG_INFO("The given language is equal to the detected language: " + detected_language);
+            LOG_INFO("The given language is equal to the " + configured_or_detected_info + " language: " + detected_language);
         else {
-            LOG_INFO("The given language " + StringUtil::Join(metadata_record->languages_, ",") + " and the detected language " + detected_language + " are different. "
+            LOG_INFO("The given language " + StringUtil::Join(metadata_record->languages_, ",") + " and the " + configured_or_detected_info + " language " + detected_language + " are different. "
                      "No language will be set.");
             metadata_record->languages_.clear();
         }

--- a/cpp/lib/src/ZoteroHarvesterConversion.cc
+++ b/cpp/lib/src/ZoteroHarvesterConversion.cc
@@ -539,9 +539,12 @@ void NormalizeGivenLanguages(MetadataRecord * const metadata_record) {
     std::set<std::string> languages(metadata_record->languages_);
     metadata_record->languages_.clear();
     for (const auto &language : languages) {
-        if (not Config::IsAllowedLanguage(language))
+        if (not Config::IsAllowedLanguage(language)) {
             LOG_WARNING("Removing invalid language: " + language);
-        else if (not Config::IsNormalizedLanguage(language)) {
+            continue;
+        }
+
+        if (not Config::IsNormalizedLanguage(language)) {
             const std::string normalized_language(Config::GetNormalizedLanguage(language));
             LOG_INFO("Normalized language: " + language + " => " + normalized_language);
             metadata_record->languages_.emplace(normalized_language);


### PR DESCRIPTION
- follow-up PR to #3805
- Allow multiple languages in MetadataRecord => multiple changes necessary to allow this
- Renamed+Splitted the very large DetectLanguage function into several smaller functions to make things clearer
- Added support for '!' and '?'
- Still keep backwards compatibility for non-merged force_language_detection entries