### PR TITLE
additional log info for matched tag number

### DIFF
--- a/cpp/marc_tools/single_marc_convert_keywords.cc
+++ b/cpp/marc_tools/single_marc_convert_keywords.cc
@@ -67,7 +67,7 @@ void AddMainSubfieldAndCombinationsToGndKeywords(const MARC::Record &record, std
     if (subfield_codes.find('a') != std::string::npos) {
         const std::string subfield_value_a(record.getFirstSubfieldValue(field_tag, 'a'));
         if (not subfield_value_a.empty())
-            keywords_to_gnd_numbers_map->emplace(std::make_pair(subfield_value_a, record.getControlNumber()));
+            keywords_to_gnd_numbers_map->emplace(std::make_pair(subfield_value_a, record.getControlNumber() + " & " + field_tag));
     }
     std::vector<std::string> subfields;
     ExtractSubfieldsForTag(record, field_tag, subfield_codes, &subfields);
@@ -103,8 +103,10 @@ void FindEquivalentKeywords(std::unordered_map<std::string, std::string> const &
         const auto gnd_number(keywords_to_gnd_numbers_map.find(keyword));
         if (gnd_number == keywords_to_gnd_numbers_map.end())
             keywords_without_match.insert(keyword);
-        else
+        else {
             keywords_to_ppns_map.insert(*gnd_number);
+            LOG_INFO("Keyword '" + keyword + "' matched to PPN & Tag '" + gnd_number->second + "' \n");
+        }
     }
     LOG_INFO("Found " + std::to_string(keywords_to_ppns_map.size()) + " keyword match(es).\n");
     const double percentage((static_cast<double>(keywords_to_ppns_map.size()) / static_cast<double>(keywords_to_compare.size())) * 100);


### PR DESCRIPTION
I wasn't sure whether that was the approach you were looking / hoping for.
The issue with the approach of a second map mapping ppn and tags was that there would be multiple entries for the same ppn mapping to all the tags, meaning we wouldn't be able to filter the right tags anymore. At least that's how I understood it.
Therefore I added the tag information to the keywords_to_gnd_numbers_map 's value, which in return means it'll show up in the output file for matching keywords. If this outcome is not desirable, just ignore this PR.