### PR TITLE
boot_notification.service: Added [Install] section

### DIFF
--- a/cpp/data/installer/boot_notification.service
+++ b/cpp/data/installer/boot_notification.service
@@ -5,3 +5,6 @@ After=systemd-user-sessions.service
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/boot_notification.sh
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Without this section, `systemctl enable boot_notification.service` will produce a warning and the service will not be enabled for being executed after reboot:

```
The unit files have no installation config (WantedBy, RequiredBy, Also, Alias
settings in the [Install] section, and DefaultInstance for template units).
This means they are not meant to be enabled using systemctl.
Possible reasons for having this kind of units are:
1) A unit may be statically enabled by being symlinked from another unit's
   .wants/ or .requires/ directory.
2) A unit's purpose may be to act as a helper for some other unit which has
   a requirement dependency on it.
3) A unit may be started when needed via activation (socket, path, timer,
   D-Bus, udev, scripted systemctl call, ...).
4) In case of template units, the unit is meant to be enabled with some
   instance name specified.
```