### PR TITLE
installer.cc: Moved granting of privileges from ixtheo.sql to installer.cc

### DIFF
--- a/cpp/data/installer/ixtheo.sql
+++ b/cpp/data/installer/ixtheo.sql
@@ -43,6 +43,3 @@ CREATE TABLE translators (
   PRIMARY KEY (translator, translation_target)
 ) DEFAULT CHARSET=utf8mb4;
 
-GRANT CREATE TEMPORARY TABLES ON ixtheo.* TO 'ixtheo'@'localhost';
-GRANT ALL ON ixtheo.* TO 'ub_tools'@'localhost';
-GRANT ALL ON ixtheo.* TO 'vufind'@'localhost';

--- a/cpp/installer.cc
+++ b/cpp/installer.cc
@@ -378,8 +378,6 @@ void CreateVuFindDatabases(const VuFindSystemType vufind_system_type, DbConnecti
             MySQLImportFileIfExists(VUFIND_DIRECTORY + "/module/KrimDok/sql/mysql.sql", sql_database, sql_username, sql_password);
             break;
         }
-
-
     }
 
     if (vufind_system_type == IXTHEO) {
@@ -393,6 +391,8 @@ void CreateVuFindDatabases(const VuFindSystemType vufind_system_type, DbConnecti
             Echo("creating " + ixtheo_database + " database");
             db_connection_root->mySQLCreateDatabase(ixtheo_database);
             db_connection_root->mySQLGrantAllPrivileges(ixtheo_database, ixtheo_username);
+            db_connection_root->mySQLGrantAllPrivileges(ixtheo_database, sql_username);
+            db_connection_root->mySQLGrantAllPrivileges(ixtheo_database, "ub_tools");
             DbConnection::MySQLImportFile(INSTALLER_DATA_DIRECTORY + "/ixtheo.sql", ixtheo_database, ixtheo_username, ixtheo_password);
         }
     }


### PR DESCRIPTION
@jriedl: We will merge this to solve a problem during the installation of the new test server. Also, we found some documentation saying that CREATE TEMPORARY TABLES is already part of ALL PRIVILEGES in database context. Please have a short look at it anyway when time permits, just to make sure there will be no ubuntu-related problems later.