### PR TITLE
docker: Shared Makefile.inc for ixtheo-ubuntu & krimdok-ubuntu (+reduced amount of data copied from /mnt)

### DIFF
--- a/docker/Makefile.inc
+++ b/docker/Makefile.inc
@@ -7,7 +7,6 @@ ubuntu_prepare_deps:
 	if [ -z "$(docker images -q ub_tools-deps-ubuntu)" ]; then \
 		cd /usr/local/ub_tools/docker/ub_tools-deps-ubuntu; \
 		make ; \
-		cd /usr/local/ub_tools/docker/ixtheo-ubuntu; \
 	fi
 	if [ ! -d "mnt/ZE020150" ]; then \
 		mkdir -p mnt/ZE020150; \

--- a/docker/Makefile.inc
+++ b/docker/Makefile.inc
@@ -1,0 +1,26 @@
+ubuntu_clean_deps:
+	docker image rm -f ub_tools-deps-ubuntu
+	rm -rf mnt/ZE020150
+	rm -f .smbcredentials
+
+ubuntu_prepare_deps:
+	if [ -z "$(docker images -q ub_tools-deps-ubuntu)" ]; then \
+		cd /usr/local/ub_tools/docker/ub_tools-deps-ubuntu; \
+		make ; \
+		cd /usr/local/ub_tools/docker/ixtheo-ubuntu; \
+	fi
+	if [ ! -d "mnt/ZE020150" ]; then \
+		mkdir -p mnt/ZE020150; \
+		mkdir -p mnt/ZE020150/FID-Entwicklung; \
+                cp /mnt/ZE020150/FID-Entwicklung/Makefile mnt/ZE020150/FID-Entwicklung; \
+                cp /mnt/ZE020150/FID-Entwicklung/github-robot mnt/ZE020150/FID-Entwicklung; \
+                cp /mnt/ZE020150/FID-Entwicklung/github-robot.pub mnt/ZE020150/FID-Entwicklung; \
+		cp -r /mnt/ZE020150/FID-Entwicklung/ub_tools mnt/ZE020150/FID-Entwicklung; \
+		cp -r /mnt/ZE020150/FID-Entwicklung/IxTheo mnt/ZE020150/FID-Entwicklung; \
+		cp -r /mnt/ZE020150/FID-Entwicklung/KrimDok mnt/ZE020150/FID-Entwicklung; \
+	fi
+	if [ ! -f ".smbcredentials" ]; then \
+		cp -f /root/.smbcredentials .smbcredentials; \
+	fi
+
+.DEFAULT_GOAL := docker_build

--- a/docker/Makefile.inc
+++ b/docker/Makefile.inc
@@ -12,12 +12,14 @@ ubuntu_prepare_deps:
 	if [ ! -d "mnt/ZE020150" ]; then \
 		mkdir -p mnt/ZE020150; \
 		mkdir -p mnt/ZE020150/FID-Entwicklung; \
-                cp /mnt/ZE020150/FID-Entwicklung/Makefile mnt/ZE020150/FID-Entwicklung; \
-                cp /mnt/ZE020150/FID-Entwicklung/github-robot mnt/ZE020150/FID-Entwicklung; \
-                cp /mnt/ZE020150/FID-Entwicklung/github-robot.pub mnt/ZE020150/FID-Entwicklung; \
+		cp /mnt/ZE020150/FID-Entwicklung/Makefile mnt/ZE020150/FID-Entwicklung; \
+		cp /mnt/ZE020150/FID-Entwicklung/github-robot mnt/ZE020150/FID-Entwicklung; \
+		cp /mnt/ZE020150/FID-Entwicklung/github-robot.pub mnt/ZE020150/FID-Entwicklung; \
 		cp -r /mnt/ZE020150/FID-Entwicklung/ub_tools mnt/ZE020150/FID-Entwicklung; \
 		cp -r /mnt/ZE020150/FID-Entwicklung/IxTheo mnt/ZE020150/FID-Entwicklung; \
 		cp -r /mnt/ZE020150/FID-Entwicklung/KrimDok mnt/ZE020150/FID-Entwicklung; \
+		mkdir -p mnt/ZE020150/FID-Entwicklung/fulltext; \
+		cp -r /mnt/ZE020150/FID-Entwicklung/fulltext/synonyms mnt/ZE020150/FID-Entwicklung/fulltext; \
 	fi
 	if [ ! -f ".smbcredentials" ]; then \
 		cp -f /root/.smbcredentials .smbcredentials; \

--- a/docker/ixtheo-ubuntu/Makefile
+++ b/docker/ixtheo-ubuntu/Makefile
@@ -1,25 +1,6 @@
-docker_build:
-	if [ -z "$(docker images -q ub_tools-deps-ubuntu)" ]; then \
-                cd /usr/local/ub_tools/docker/ub_tools-deps-ubuntu; \
-                make ; \
-                cd /usr/local/ub_tools/docker/ixtheo-ubuntu; \
-        fi
-	if [ ! -d "mnt/ZE020150" ]; then \
-		mkdir -p mnt/ZE020150; \
-		cp -r /mnt/ZE020150/FID-Entwicklung mnt/ZE020150; \
-	fi
-	if [ ! -f ".smbcredentials" ]; then \
-		cp -f /root/.smbcredentials .smbcredentials; \
-	fi
+include ../Makefile.inc
+
+docker_build: ubuntu_prepare_deps
 	docker build -t ixtheo-ubuntu .
-nocache:
-	if [ -z "$(docker images -q ub_tools-deps-ubuntu)" ]; then \
-                cd /usr/local/ub_tools/docker/ub_tools-deps-ubuntu; \
-                make ; \
-                cd /usr/local/ub_tools/docker/ixtheo-ubuntu; \
-        fi
-	rm -r mnt/ZE020150
-	mkdir -p mnt/ZE020150
-	cp -r /mnt/ZE020150/FID-Entwicklung mnt/ZE020150
-	cp -f /root/.smbcredentials .smbcredentials
+nocache: ubuntu_clean_deps ubuntu_prepare_deps
 	docker build --no-cache -t ixtheo-ubuntu .

--- a/docker/krimdok-ubuntu/Makefile
+++ b/docker/krimdok-ubuntu/Makefile
@@ -1,25 +1,6 @@
-docker_build:
-	if [ -z "$(docker images -q ub_tools-deps-ubuntu)" ]; then \
-                cd /usr/local/ub_tools/docker/ub_tools-deps-ubuntu; \
-                make ; \
-                cd /usr/local/ub_tools/docker/krimdok-ubuntu; \
-        fi
-	if [ ! -d "mnt/ZE020150" ]; then \
-		mkdir -p mnt/ZE020150; \
-		cp -r /mnt/ZE020150/FID-Entwicklung mnt/ZE020150; \
-	fi
-	if [ ! -f ".smbcredentials" ]; then \
-		cp /root/.smbcredentials .smbcredentials; \
-	fi
+include ../Makefile.inc
+
+docker_build: ubuntu_prepare_deps
 	docker build -t krimdok-ubuntu .
-nocache:
-	if [ -z "$(docker images -q ub_tools-deps-ubuntu)" ]; then \
-                cd /usr/local/ub_tools/docker/ub_tools-deps-ubuntu; \
-                make ; \
-                cd /usr/local/ub_tools/docker/krimdok-ubuntu; \
-        fi
-	rm -r mnt/ZE020150
-	mkdir -p mnt/ZE020150
-	cp -r /mnt/ZE020150/FID-Entwicklung mnt/ZE020150
-	cp -f /root/.smbcredentials .smbcredentials
+nocache: ubuntu_clean_deps ubuntu_prepare_deps
 	docker build --no-cache -t krimdok-ubuntu .


### PR DESCRIPTION
... this way we save about 10 GB of data which no longer need to be copied each time we build a docker container.