### PR TITLE
109.vufind.sql: system update for vufind.tuefind_publications table

### DIFF
--- a/cpp/data/system_updates/109.vufind.sql
+++ b/cpp/data/system_updates/109.vufind.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS tuefind_publications;
+CREATE TABLE tuefind_publications (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    control_number VARCHAR(255) NOT NULL,
+    external_document_id VARCHAR(255) NOT NULL,
+    terms_date DATE NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY publication_control_number (control_number),
+    UNIQUE KEY publication_external_document_id (external_document_id),
+    FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+) DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_bin;


### PR DESCRIPTION
belongs to ubtue/tuefind#2035
table wasn't use in live mode yet, so it will simply be dropped & re-created with the new schema.