### PR TITLE
VuFind 8.1: Add new "assets" directory to apache configuration in docker images

### DIFF
--- a/docker/ixtheo/apache2/vufind-bibstudies.conf
+++ b/docker/ixtheo/apache2/vufind-bibstudies.conf
@@ -9,11 +9,8 @@ AliasMatch ^/cache/([0-9a-zA-Z-_]*)/(.*)$ /usr/local/vufind/local/tuefind/instan
 </Directory>
 
 # Configuration for theme-specific resources:
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/css/(.*)$ /usr/local/vufind/themes/$1/css/$2
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/docs/(.*)$ /usr/local/vufind/themes/$1/docs/$2
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/images/(.*)$ /usr/local/vufind/themes/$1/images/$2
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/js/(.*)$ /usr/local/vufind/themes/$1/js/$2
-<Directory ~ "^/usr/local/vufind/themes/([0-9a-zA-Z-_]*)/(css|docs|images|js)/">
+AliasMatch ^/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/(.*)$ /usr/local/vufind/themes/$1/$2/$3
+<Directory ~ "^/usr/local/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/">
   Require all granted
   AllowOverride All
 </Directory>

--- a/docker/ixtheo/apache2/vufind-bibstudies.conf
+++ b/docker/ixtheo/apache2/vufind-bibstudies.conf
@@ -9,7 +9,7 @@ AliasMatch ^/cache/([0-9a-zA-Z-_]*)/(.*)$ /usr/local/vufind/local/tuefind/instan
 </Directory>
 
 # Configuration for theme-specific resources:
-AliasMatch ^/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/(.*)$ /usr/local/vufind/themes/$1/$2/$3
+AliasMatch ^/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/(.*)$ /usr/local/vufind/themes/$1/$2/$3
 <Directory ~ "^/usr/local/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/">
   Require all granted
   AllowOverride All

--- a/docker/ixtheo/apache2/vufind-churchlaw.conf
+++ b/docker/ixtheo/apache2/vufind-churchlaw.conf
@@ -9,11 +9,8 @@ AliasMatch ^/cache/([0-9a-zA-Z-_]*)/(.*)$ /usr/local/vufind/local/tuefind/instan
 </Directory>
 
 # Configuration for theme-specific resources:
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/css/(.*)$ /usr/local/vufind/themes/$1/css/$2
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/docs/(.*)$ /usr/local/vufind/themes/$1/docs/$2
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/images/(.*)$ /usr/local/vufind/themes/$1/images/$2
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/js/(.*)$ /usr/local/vufind/themes/$1/js/$2
-<Directory ~ "^/usr/local/vufind/themes/([0-9a-zA-Z-_]*)/(css|docs|images|js)/">
+AliasMatch ^/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/(.*)$ /usr/local/vufind/themes/$1/$2/$3
+<Directory ~ "^/usr/local/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/">
   Require all granted
   AllowOverride All
 </Directory>

--- a/docker/ixtheo/apache2/vufind-churchlaw.conf
+++ b/docker/ixtheo/apache2/vufind-churchlaw.conf
@@ -9,7 +9,7 @@ AliasMatch ^/cache/([0-9a-zA-Z-_]*)/(.*)$ /usr/local/vufind/local/tuefind/instan
 </Directory>
 
 # Configuration for theme-specific resources:
-AliasMatch ^/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/(.*)$ /usr/local/vufind/themes/$1/$2/$3
+AliasMatch ^/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/(.*)$ /usr/local/vufind/themes/$1/$2/$3
 <Directory ~ "^/usr/local/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/">
   Require all granted
   AllowOverride All

--- a/docker/ixtheo/apache2/vufind-ixtheo.conf
+++ b/docker/ixtheo/apache2/vufind-ixtheo.conf
@@ -9,11 +9,8 @@ AliasMatch ^/cache/([0-9a-zA-Z-_]*)/(.*)$ /usr/local/vufind/local/tuefind/instan
 </Directory>
 
 # Configuration for theme-specific resources:
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/css/(.*)$ /usr/local/vufind/themes/$1/css/$2
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/docs/(.*)$ /usr/local/vufind/themes/$1/docs/$2
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/images/(.*)$ /usr/local/vufind/themes/$1/images/$2
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/js/(.*)$ /usr/local/vufind/themes/$1/js/$2
-<Directory ~ "^/usr/local/vufind/themes/([0-9a-zA-Z-_]*)/(css|docs|images|js)/">
+AliasMatch ^/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/(.*)$ /usr/local/vufind/themes/$1/$2/$3
+<Directory ~ "^/usr/local/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/">
   Require all granted
   AllowOverride All
 </Directory>

--- a/docker/ixtheo/apache2/vufind-ixtheo.conf
+++ b/docker/ixtheo/apache2/vufind-ixtheo.conf
@@ -9,7 +9,7 @@ AliasMatch ^/cache/([0-9a-zA-Z-_]*)/(.*)$ /usr/local/vufind/local/tuefind/instan
 </Directory>
 
 # Configuration for theme-specific resources:
-AliasMatch ^/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/(.*)$ /usr/local/vufind/themes/$1/$2/$3
+AliasMatch ^/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/(.*)$ /usr/local/vufind/themes/$1/$2/$3
 <Directory ~ "^/usr/local/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/">
   Require all granted
   AllowOverride All

--- a/docker/ixtheo/apache2/vufind-relbib.conf
+++ b/docker/ixtheo/apache2/vufind-relbib.conf
@@ -9,11 +9,8 @@ AliasMatch ^/cache/([0-9a-zA-Z-_]*)/(.*)$ /usr/local/vufind/local/tuefind/instan
 </Directory>
 
 # Configuration for theme-specific resources:
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/css/(.*)$ /usr/local/vufind/themes/$1/css/$2
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/docs/(.*)$ /usr/local/vufind/themes/$1/docs/$2
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/images/(.*)$ /usr/local/vufind/themes/$1/images/$2
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/js/(.*)$ /usr/local/vufind/themes/$1/js/$2
-<Directory ~ "^/usr/local/vufind/themes/([0-9a-zA-Z-_]*)/(css|docs|images|js)/">
+AliasMatch ^/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/(.*)$ /usr/local/vufind/themes/$1/$2/$3
+<Directory ~ "^/usr/local/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/">
   Require all granted
   AllowOverride All
 </Directory>

--- a/docker/ixtheo/apache2/vufind-relbib.conf
+++ b/docker/ixtheo/apache2/vufind-relbib.conf
@@ -9,7 +9,7 @@ AliasMatch ^/cache/([0-9a-zA-Z-_]*)/(.*)$ /usr/local/vufind/local/tuefind/instan
 </Directory>
 
 # Configuration for theme-specific resources:
-AliasMatch ^/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/(.*)$ /usr/local/vufind/themes/$1/$2/$3
+AliasMatch ^/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/(.*)$ /usr/local/vufind/themes/$1/$2/$3
 <Directory ~ "^/usr/local/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/">
   Require all granted
   AllowOverride All

--- a/docker/krimdok/apache2/vufind-krimdok.conf
+++ b/docker/krimdok/apache2/vufind-krimdok.conf
@@ -9,11 +9,8 @@ AliasMatch ^/cache/([0-9a-zA-Z-_]*)/(.*)$ /usr/local/vufind/local/tuefind/instan
 </Directory>
 
 # Configuration for theme-specific resources:
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/css/(.*)$ /usr/local/vufind/themes/$1/css/$2
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/docs/(.*)$ /usr/local/vufind/themes/$1/docs/$2
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/images/(.*)$ /usr/local/vufind/themes/$1/images/$2
-AliasMatch ^/themes/([0-9a-zA-Z-_]*)/js/(.*)$ /usr/local/vufind/themes/$1/js/$2
-<Directory ~ "^/usr/local/vufind/themes/([0-9a-zA-Z-_]*)/(css|docs|images|js)/">
+AliasMatch ^/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/(.*)$ /usr/local/vufind/themes/$1/$2/$3
+<Directory ~ "^/usr/local/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/">
   Require all granted
   AllowOverride All
 </Directory>

--- a/docker/krimdok/apache2/vufind-krimdok.conf
+++ b/docker/krimdok/apache2/vufind-krimdok.conf
@@ -9,7 +9,7 @@ AliasMatch ^/cache/([0-9a-zA-Z-_]*)/(.*)$ /usr/local/vufind/local/tuefind/instan
 </Directory>
 
 # Configuration for theme-specific resources:
-AliasMatch ^/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/(.*)$ /usr/local/vufind/themes/$1/$2/$3
+AliasMatch ^/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/(.*)$ /usr/local/vufind/themes/$1/$2/$3
 <Directory ~ "^/usr/local/vufind/themes/([0-9a-zA-Z-_]*)/(assets|css|docs|images|js)/">
   Require all granted
   AllowOverride All


### PR DESCRIPTION
Refers to ubtue/tuefind#2309 but should be backwards compatible.