### PR TITLE
Sort the filter data and the target data provider id before check the intersection

### DIFF
--- a/cpp/harvest/core.cc
+++ b/cpp/harvest/core.cc
@@ -310,11 +310,13 @@ void Filter(int argc, char **argv) {
             filter_data_provider_ids.emplace_back(StringUtil::ToUnsignedLong(line));
         }
     }
-
+    std::sort(filter_data_provider_ids.begin(), filter_data_provider_ids.end());
 
     for (auto work : works) {
         if (not filter_data_provider_ids.empty()) {
-            const bool is_in(MiscUtil::Intersect(work.getDataProviderIds(), filter_data_provider_ids).size() > 0);
+            auto sortedDataProvider = work.getDataProviderIds();
+            std::sort(sortedDataProvider.begin(), sortedDataProvider.end());
+            const bool is_in(MiscUtil::Intersect(sortedDataProvider, filter_data_provider_ids).size() > 0);
             if (is_in == filter) {
                 work.setFilteredReason("Data Provider");
                 CORE::OutputFileAppend(filter_file, work, skipped == 0);


### PR DESCRIPTION
Fixing the error regarding the number of affected data.
See.
https://en.cppreference.com/w/cpp/algorithm/set_intersection