### PR TITLE
Update marc_issn_lookup

### DIFF
--- a/cpp/harvest/marc_issn_lookup.cc
+++ b/cpp/harvest/marc_issn_lookup.cc
@@ -186,17 +186,23 @@ void ShowInfoForDebugging(const std::vector<CacheEntry> &journal_cache, const st
     }
 
     if (not debug_info.ppns_with_issn_not_recognized_.empty()) {
-        std::cout << "******** Start of PPN with ISSN has not found in k10plus and issn.org ***********" << std::endl;
+        std::cout << "******** Start of PPN with ISSN has not found or invalid in k10plus, and not found in issn.org or timeout while "
+                     "downloading ***********"
+                  << std::endl;
         for (const auto &pnr : debug_info.ppns_with_issn_not_recognized_)
             std::cout << "PPN: " << pnr.first << ", ISSN: " << pnr.second << std::endl;
-        std::cout << "******** End of PPN with ISSN has not found in k10plus and issn.org ***********\n\n";
+        std::cout << "******** End of PPN with ISSN has not found or invalid in k10plus, and not found in issn.org or timeout while "
+                     "downloading  ***********\n\n";
     }
 
     if (not debug_info.issns_not_found_.empty()) {
-        std::cout << "******** Start of ISSN has not found ***********" << std::endl;
+        std::cout << "******** Start of ISSN has not found or invalid in k10plus, and not found in issn.org or timeout while downloading "
+                     "***********"
+                  << std::endl;
         for (const auto &isf : debug_info.issns_not_found_)
             std::cout << "ISSN: " << isf << std::endl;
-        std::cout << "******** End of ISSN has not found ***********\n\n";
+        std::cout << "******** End of ISSN has not found or invalid in k10plus, and not found in issn.org or timeout while downloading "
+                     "***********\n\n";
     }
 }
 

--- a/cpp/harvest/marc_issn_lookup.cc
+++ b/cpp/harvest/marc_issn_lookup.cc
@@ -42,6 +42,13 @@ namespace {
     std::exit(EXIT_FAILURE);
 }
 
+struct DebugInfo {
+    std::map<std::string, std::string> ppns_use_issn_org_, ppns_use_k10_, ppns_with_issn_not_recognized_,
+        ppns_with_issn_in_k10_but_invalid_;
+    std::set<std::string> issns_not_found_;
+    DebugInfo() = default;
+};
+
 // avoiding duplication in issns's cache
 void InsertIssnIfNotExist(const std::string &issn, std::vector<std::string> * const issns) {
     if (std::find(issns->begin(), issns->end(), StringUtil::ASCIIToUpper(issn)) == issns->end())
@@ -132,10 +139,8 @@ void PrettyPrintCacheEntry(const CacheEntry &ce) {
 }
 
 
-void PrettyPrintCache(const std::vector<CacheEntry> &journal_cache, const std::vector<IssnLookup::ISSNInfo> &issn_org_cache,
-                      const std::map<std::string, std::string> &ppns_use_issn_org,
-                      const std::map<std::string, std::string> &ppns_with_issn_not_recognized,
-                      const std::set<std::string> &issns_not_found) {
+void ShowInfoForDebugging(const std::vector<CacheEntry> &journal_cache, const std::vector<IssnLookup::ISSNInfo> &issn_org_cache,
+                          const DebugInfo &debug_info) {
     unsigned i(1);
     std::cout << "********* Cache (ISSN found in K10plus) *********" << std::endl;
     for (const auto &jc : journal_cache) {
@@ -158,25 +163,40 @@ void PrettyPrintCache(const std::vector<CacheEntry> &journal_cache, const std::v
         std::cout << "******** End of Cache (ISSN found in issn.org) ***********\n\n";
     }
 
-    if (not ppns_use_issn_org.empty()) {
+    if (not debug_info.ppns_use_k10_.empty()) {
+        std::cout << "******** Start of PPN used issn data from K10Plus ***********" << std::endl;
+        for (const auto &pu : debug_info.ppns_use_k10_)
+            std::cout << "PPN: " << pu.first << ", ISSN: " << pu.second << std::endl;
+        std::cout << "******** End of PPN used issn data from K10Plus ***********\n\n";
+    }
+
+    if (not debug_info.ppns_with_issn_in_k10_but_invalid_.empty()) {
+        std::cout << "******** Start of PPN with ISSN found in k10plus but invalid and took information from issn.org ***********"
+                  << std::endl;
+        for (const auto &pnr : debug_info.ppns_with_issn_in_k10_but_invalid_)
+            std::cout << "PPN: " << pnr.first << ", ISSN: " << pnr.second << std::endl;
+        std::cout << "******** End of PPN with ISSN found in k10plus but invalid and took information from issn.org ***********\n\n";
+    }
+
+    if (not debug_info.ppns_use_issn_org_.empty()) {
         std::cout << "******** Start of PPN used issn data from issn.org ***********" << std::endl;
-        for (const auto &pu : ppns_use_issn_org)
+        for (const auto &pu : debug_info.ppns_use_issn_org_)
             std::cout << "PPN: " << pu.first << ", ISSN: " << pu.second << std::endl;
         std::cout << "******** End of PPN used issn data from issn.org ***********\n\n";
     }
 
-    if (not ppns_with_issn_not_recognized.empty()) {
-        std::cout << "******** Start of PPN used issn data from issn.org ***********" << std::endl;
-        for (const auto &pnr : ppns_with_issn_not_recognized)
+    if (not debug_info.ppns_with_issn_not_recognized_.empty()) {
+        std::cout << "******** Start of PPN with ISSN has not found in k10plus and issn.org ***********" << std::endl;
+        for (const auto &pnr : debug_info.ppns_with_issn_not_recognized_)
             std::cout << "PPN: " << pnr.first << ", ISSN: " << pnr.second << std::endl;
-        std::cout << "******** End of PPN used issn data from issn.org ***********\n\n";
+        std::cout << "******** End of PPN with ISSN has not found in k10plus and issn.org ***********\n\n";
     }
 
-    if (not issns_not_found.empty()) {
-        std::cout << "******** Start of ISSN was not found ***********" << std::endl;
-        for (const auto &isf : issns_not_found)
+    if (not debug_info.issns_not_found_.empty()) {
+        std::cout << "******** Start of ISSN has not found ***********" << std::endl;
+        for (const auto &isf : debug_info.issns_not_found_)
             std::cout << "ISSN: " << isf << std::endl;
-        std::cout << "******** End of ISSN was not found ***********\n\n";
+        std::cout << "******** End of ISSN has not found ***********\n\n";
     }
 }
 
@@ -218,15 +238,15 @@ void UpdateSubfieldUsingK10(MARC::Subfields &subfields, const CacheEntry &cache_
             subfields.addSubfield('t', cache_entry.preferred_title_);
 }
 
-void UpdateSubfieldUsingISSNOrg(MARC::Subfields &subfields, const IssnLookup::ISSNInfo issn_info) {
-    if (!subfields.replaceFirstSubfield('i', "In:"))
-        subfields.addSubfield('i', "In:");
-    if (!subfields.replaceFirstSubfield('x', issn_info.issn_))
-        subfields.addSubfield('x', issn_info.issn_);
+void UpdateSubfieldUsingISSNOrg(MARC::Subfields &subfields, const IssnLookup::ISSNInfo issn_info, const bool &is_in_k10plus_but_invalid) {
+    if (!is_in_k10plus_but_invalid) {
+        if (!subfields.replaceFirstSubfield('i', "In:"))
+            subfields.addSubfield('i', "In:");
+    }
 
-    if (not issn_info.main_title_.empty())
-        if (!subfields.replaceFirstSubfield('t', issn_info.main_title_))
-            subfields.addSubfield('t', issn_info.main_title_);
+    if (not issn_info.main_titles_.empty())
+        if (!subfields.replaceFirstSubfield('t', issn_info.main_titles_.front()))
+            subfields.addSubfield('t', issn_info.main_titles_.front());
 }
 
 void UpdateCacheEntry(CacheEntry &ce, const CacheEntry &new_ce, const bool is_online) {
@@ -362,63 +382,84 @@ void CleanDuplicationOfField773(MARC::Record * const record) {
 
 
 void ISSNLookup(char **argv, std::vector<CacheEntry> &journal_cache, std::vector<IssnLookup::ISSNInfo> * const issn_org_cache,
-                std::map<std::string, std::string> * const ppns_use_issn_org,
-                std::map<std::string, std::string> * const ppns_with_issn_not_recognized, std::set<std::string> * const issns_not_found) {
+                DebugInfo * const debug_info, const bool &debug_mode) {
     auto input_file(MARC::Reader::Factory(argv[1]));
     auto output_file(MARC::Writer::Factory(argv[3]));
-    std::vector<std::string> updated_ppn, ignored_ppn;
+    std::set<std::string> invalid_issns_ink10plus;
 
     while (MARC::Record record = input_file->read()) {
         std::string ppn("");
         for (auto &field : record) {
-            bool is_issn_in_k10plus(false);
+            MARC::Subfields subfields(field.getSubfields());
+            bool is_issn_in_k10plus(false), is_in_k10plus_but_invalid(false);
             if (field.getTag() == "001")
                 ppn = field.getContents();
 
             if (field.getTag() == "773") {
                 const std::string issn(StringUtil::ASCIIToUpper(field.getFirstSubfieldWithCode('x')));
                 if (not issn.empty()) {
-                    if (issns_not_found->find(issn) == issns_not_found->end()) {
-                        // data is found
-                        for (const auto &elemt : journal_cache) {
-                            bool is_in_l = (std::find(elemt.issns_.begin(), elemt.issns_.end(), issn) != elemt.issns_.end() ? true : false);
-                            if ((elemt.preferred_issn_ == issn) || is_in_l) {
-                                if (elemt.is_valid_) {
-                                    MARC::Subfields subfields(field.getSubfields());
-                                    UpdateSubfieldUsingK10(subfields, elemt);
-                                    field.setSubfields(subfields);
+                    // data is found or need to check it first
+                    if (debug_info->issns_not_found_.find(issn) == debug_info->issns_not_found_.end()) {
+                        // and invalid
+                        if (invalid_issns_ink10plus.find(issn) == invalid_issns_ink10plus.end()) {
+                            for (const auto &elemt : journal_cache) {
+                                bool is_in_l =
+                                    (std::find(elemt.issns_.begin(), elemt.issns_.end(), issn) != elemt.issns_.end() ? true : false);
+                                if ((elemt.preferred_issn_ == issn) || is_in_l) {
+                                    if (elemt.is_valid_) {
+                                        UpdateSubfieldUsingK10(subfields, elemt);
+                                        field.setSubfields(subfields);
+
+                                        if (debug_mode)
+                                            debug_info->ppns_use_k10_.insert(std::make_pair(ppn, issn));
+
+                                    } else {
+                                        is_in_k10plus_but_invalid = true;
+                                        invalid_issns_ink10plus.insert(issn);
+                                    }
+                                    // issn is found in k10, ignoring wheather it is if valid or not
+                                    is_issn_in_k10plus = true;
+                                    break;
                                 }
-                                // issn is found in k10, ignoring wheather it is if valid or not
-                                is_issn_in_k10plus = true;
-                                break;
                             }
+                        } else {
+                            is_in_k10plus_but_invalid = true;
                         }
-                        if (not is_issn_in_k10plus) {
+                        if (not is_issn_in_k10plus || is_in_k10plus_but_invalid) {
                             IssnLookup::ISSNInfo issn_info;
                             if (IsInISSNInfoCache(issn, *issn_org_cache, &issn_info)) {
                                 // issn is in the issn info cache already
-                                MARC::Subfields subfields(field.getSubfields());
-                                UpdateSubfieldUsingISSNOrg(subfields, issn_info);
+                                UpdateSubfieldUsingISSNOrg(subfields, issn_info, is_in_k10plus_but_invalid);
                                 field.setSubfields(subfields);
+                                if (debug_mode) {
+                                    (is_in_k10plus_but_invalid
+                                         ? debug_info->ppns_with_issn_in_k10_but_invalid_.insert(std::make_pair(ppn, issn))
+                                         : debug_info->ppns_use_issn_org_.insert(std::make_pair(ppn, issn)));
+                                }
+
                             } else {
                                 if (IssnLookup::GetISSNInfo(issn, &issn_info)) {
                                     issn_org_cache->emplace_back(issn_info);
-                                    MARC::Subfields subfields(field.getSubfields());
-                                    UpdateSubfieldUsingISSNOrg(subfields, issn_info);
+                                    UpdateSubfieldUsingISSNOrg(subfields, issn_info, is_in_k10plus_but_invalid);
                                     field.setSubfields(subfields);
-                                    ppns_use_issn_org->insert(std::make_pair(ppn, issn));
+                                    if (debug_mode) {
+                                        (is_in_k10plus_but_invalid
+                                             ? debug_info->ppns_with_issn_in_k10_but_invalid_.insert(std::make_pair(ppn, issn))
+                                             : debug_info->ppns_use_issn_org_.insert(std::make_pair(ppn, issn)));
+                                    }
 
                                 } else {
                                     // issn was not found
-                                    issns_not_found->insert(issn);
-                                    ppns_with_issn_not_recognized->insert(std::make_pair(ppn, issn));
+                                    if (debug_mode) {
+                                        debug_info->issns_not_found_.insert(issn);
+                                        debug_info->ppns_with_issn_not_recognized_.insert(std::make_pair(ppn, issn));
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
-            is_issn_in_k10plus = false;
         }
         CleanDuplicationOfField773(&record);
         output_file->write(record);
@@ -435,15 +476,16 @@ int Main(int argc, char **argv) {
 
     std::vector<CacheEntry> journal_cache(BuildJournalCache(argv[2]));
     std::vector<IssnLookup::ISSNInfo> issn_org_cache;
-    std::map<std::string, std::string> ppns_use_issn_org, ppns_with_issn_not_recognized;
+    std::map<std::string, std::string> ppns_use_issn_org, ppns_with_issn_not_recognized, ppns_with_issn_in_k10_but_invalid;
     std::set<std::string> issns_not_found;
+    DebugInfo debug_info;
 
     const bool debug_mode(((argc == 5 && (std::strcmp(argv[4], "--verbose") == 0)) ? true : false));
 
-    ISSNLookup(argv, journal_cache, &issn_org_cache, &ppns_use_issn_org, &ppns_with_issn_not_recognized, &issns_not_found);
+    ISSNLookup(argv, journal_cache, &issn_org_cache, &debug_info, debug_mode);
 
     if (debug_mode)
-        PrettyPrintCache(journal_cache, issn_org_cache, ppns_use_issn_org, ppns_with_issn_not_recognized, issns_not_found);
+        ShowInfoForDebugging(journal_cache, issn_org_cache, debug_info);
 
     return EXIT_SUCCESS;
 }

--- a/cpp/lib/include/IssnLookup.h
+++ b/cpp/lib/include/IssnLookup.h
@@ -31,16 +31,16 @@ namespace IssnLookup {
  * \brief Data structure for storing ISSN info taken from https://portal.issn.org/
  */
 struct ISSNInfo {
-    std::string main_title_, // mainTitle
-        title_,              // taken the value from @id with hash #KeyTitle
-        format_,             // format
-        identifier_,         // identifier
-        type_,               // type
-        issn_,               // issn
-        is_part_of_,         // isPartOf
-        publication_;        // publication
+    std::string format_, // format
+        identifier_,     // identifier
+        type_,           // type
+        issn_,           // issn
+        publication_;    // publication
 
-    std::vector<std::string> names_, urls_;
+    std::vector<std::string> titles_, // taken the value from @id with hash #KeyTitle
+        main_titles_,                 // mainTitle
+        is_part_of_,                  // isPartOf
+        names_, urls_;
 
     ISSNInfo() = default;
 

--- a/cpp/lib/src/IssnLookup.cc
+++ b/cpp/lib/src/IssnLookup.cc
@@ -96,7 +96,7 @@ void ExtractingData(const std::string &issn, const nlohmann::json &issn_info_jso
 bool GetISSNInfo(const std::string &issn, ISSNInfo * const issn_info) {
     const std::string issn_url("https://portal.issn.org/resource/ISSN/" + issn + "?format=json");
 
-    Downloader downloader(issn_url, Downloader::Params(), (unsigned)15000);
+    Downloader downloader(issn_url, Downloader::Params());
 
     if (downloader.anErrorOccurred()) {
         LOG_WARNING("Error while downloading data for ISSN " + issn + ": " + downloader.getLastErrorMessage());

--- a/cpp/lib/src/IssnLookup.cc
+++ b/cpp/lib/src/IssnLookup.cc
@@ -96,7 +96,7 @@ void ExtractingData(const std::string &issn, const nlohmann::json &issn_info_jso
 bool GetISSNInfo(const std::string &issn, ISSNInfo * const issn_info) {
     const std::string issn_url("https://portal.issn.org/resource/ISSN/" + issn + "?format=json");
 
-    Downloader downloader(issn_url, Downloader::Params());
+    Downloader downloader(issn_url, Downloader::Params(), (unsigned)15000);
 
     if (downloader.anErrorOccurred()) {
         LOG_WARNING("Error while downloading data for ISSN " + issn + ": " + downloader.getLastErrorMessage());

--- a/cpp/lib/src/IssnLookup.cc
+++ b/cpp/lib/src/IssnLookup.cc
@@ -30,14 +30,14 @@ namespace IssnLookup {
 void ExtractingData(const std::string &issn, const nlohmann::json &issn_info_json, ISSNInfo * const issn_info) {
     const std::string issn_uri("resource/ISSN/" + issn), issn_title_uri("resource/ISSN/" + issn + "#KeyTitle");
     if (issn_info_json.at("@graph").is_structured()) {
-        for (auto ar : issn_info_json.at("@graph")) {
+        for (const auto &ar : issn_info_json.at("@graph")) {
             if (ar.is_structured()) {
                 if (ar.at("@id") == issn_uri) {
                     issn_info->issn_ = issn;
-                    for (auto &[key, val] : ar.items()) {
+                    for (const auto &[key, val] : ar.items()) {
                         if (key == "mainTitle") {
                             if (val.is_structured())
-                                for (auto val_item : val)
+                                for (const auto &val_item : val)
                                     issn_info->main_titles_.emplace_back(val_item);
                             else
                                 issn_info->main_titles_.emplace_back(val);
@@ -52,7 +52,7 @@ void ExtractingData(const std::string &issn, const nlohmann::json &issn_info_jso
 
                         if (key == "isPartOf") {
                             if (val.is_structured())
-                                for (auto val_item : val)
+                                for (const auto &val_item : val)
                                     issn_info->is_part_of_.emplace_back(val_item);
                             else
                                 issn_info->is_part_of_.emplace_back(val);
@@ -63,7 +63,7 @@ void ExtractingData(const std::string &issn, const nlohmann::json &issn_info_jso
 
                         if (key == "url") {
                             if (val.is_structured())
-                                for (auto val_item : val)
+                                for (const auto &val_item : val)
                                     issn_info->urls_.emplace_back(val_item);
                             else
                                 issn_info->urls_.emplace_back(val);
@@ -71,7 +71,7 @@ void ExtractingData(const std::string &issn, const nlohmann::json &issn_info_jso
 
                         if (key == "name") {
                             if (val.is_structured())
-                                for (auto val_item : val)
+                                for (const auto &val_item : val)
                                     issn_info->names_.emplace_back(val_item);
                             else
                                 issn_info->names_.emplace_back(val);
@@ -82,7 +82,7 @@ void ExtractingData(const std::string &issn, const nlohmann::json &issn_info_jso
                     for (auto &[key, val] : ar.items()) {
                         if (key == "value")
                             if (val.is_structured())
-                                for (auto val_item : val)
+                                for (const auto &val_item : val)
                                     issn_info->titles_.emplace_back(val_item);
                             else
                                 issn_info->titles_.emplace_back(val);
@@ -137,11 +137,11 @@ bool GetISSNInfo(const std::string &issn, ISSNInfo * const issn_info) {
 
 void ISSNInfo::PrettyPrint() {
     std::cout << "mainTitle: " << std::endl;
-    for (auto &main_title : main_titles_)
+    for (const auto &main_title : main_titles_)
         std::cout << main_title << std::endl;
 
     std::cout << "title(s): " << std::endl;
-    for (auto &title : titles_)
+    for (const auto &title : titles_)
         std::cout << title << std::endl;
 
     std::cout << "format: " << format_ << std::endl;
@@ -150,17 +150,17 @@ void ISSNInfo::PrettyPrint() {
     std::cout << "ISSN: " << issn_ << std::endl;
 
     std::cout << "isPartOf: " << std::endl;
-    for (auto &is_o : is_part_of_)
+    for (const auto &is_o : is_part_of_)
         std::cout << is_o << std::endl;
 
     std::cout << "publication: " << publication_ << std::endl;
 
     std::cout << "url: " << std::endl;
-    for (auto &url : urls_)
+    for (const auto &url : urls_)
         std::cout << url << std::endl;
 
     std::cout << "name: " << std::endl;
-    for (auto &name : names_)
+    for (const auto &name : names_)
         std::cout << name << std::endl;
 }
 

--- a/cpp/lib/src/IssnLookup.cc
+++ b/cpp/lib/src/IssnLookup.cc
@@ -35,16 +35,29 @@ void ExtractingData(const std::string &issn, const nlohmann::json &issn_info_jso
                 if (ar.at("@id") == issn_uri) {
                     issn_info->issn_ = issn;
                     for (auto &[key, val] : ar.items()) {
-                        if (key == "mainTitle")
-                            issn_info->main_title_ = val;
+                        if (key == "mainTitle") {
+                            if (val.is_structured())
+                                for (auto val_item : val)
+                                    issn_info->main_titles_.emplace_back(val_item);
+                            else
+                                issn_info->main_titles_.emplace_back(val);
+                        }
+
                         if (key == "format")
                             issn_info->format_ = val;
                         if (key == "identifier")
                             issn_info->identifier_ = val;
                         if (key == "type")
                             issn_info->type_ = val;
-                        if (key == "isPartOf")
-                            issn_info->is_part_of_ = val;
+
+                        if (key == "isPartOf") {
+                            if (val.is_structured())
+                                for (auto val_item : val)
+                                    issn_info->is_part_of_.emplace_back(val_item);
+                            else
+                                issn_info->is_part_of_.emplace_back(val);
+                        }
+
                         if (key == "publication")
                             issn_info->publication_ = val;
 
@@ -68,7 +81,11 @@ void ExtractingData(const std::string &issn, const nlohmann::json &issn_info_jso
                 if (ar.at("@id") == issn_title_uri) {
                     for (auto &[key, val] : ar.items()) {
                         if (key == "value")
-                            issn_info->title_ = val;
+                            if (val.is_structured())
+                                for (auto val_item : val)
+                                    issn_info->titles_.emplace_back(val_item);
+                            else
+                                issn_info->titles_.emplace_back(val);
                     }
                 }
             }
@@ -119,17 +136,29 @@ bool GetISSNInfo(const std::string &issn, ISSNInfo * const issn_info) {
 }
 
 void ISSNInfo::PrettyPrint() {
-    std::cout << "mainTitle: " << main_title_ << std::endl;
-    std::cout << "title: " << title_ << std::endl;
+    std::cout << "mainTitle: " << std::endl;
+    for (auto &main_title : main_titles_)
+        std::cout << main_title << std::endl;
+
+    std::cout << "title(s): " << std::endl;
+    for (auto &title : titles_)
+        std::cout << title << std::endl;
+
     std::cout << "format: " << format_ << std::endl;
     std::cout << "identifier: " << identifier_ << std::endl;
     std::cout << "type: " << type_ << std::endl;
     std::cout << "ISSN: " << issn_ << std::endl;
-    std::cout << "isPartOf: " << is_part_of_ << std::endl;
+
+    std::cout << "isPartOf: " << std::endl;
+    for (auto &is_o : is_part_of_)
+        std::cout << is_o << std::endl;
+
     std::cout << "publication: " << publication_ << std::endl;
+
     std::cout << "url: " << std::endl;
     for (auto &url : urls_)
         std::cout << url << std::endl;
+
     std::cout << "name: " << std::endl;
     for (auto &name : names_)
         std::cout << name << std::endl;


### PR DESCRIPTION
Use info from issn.org if issn is invalid in k10plus, use memory for debugging if needed, and reduce the number of parameters in ISSNLookup and ShowInfoForDebugging by creating a DebugInfo structure.
Update variable types in IssnLookup.h