### PR TITLE
docker/krimdok: Include dummy local_overrides/krimdok_kfl.conf

### DIFF
--- a/docker/krimdok/local_overrides/krimdok_kfl.conf
+++ b/docker/krimdok/local_overrides/krimdok_kfl.conf
@@ -1,0 +1,16 @@
+; this is just a dummy
+encryption_key = 01234567890123456789012345678901
+
+; licenses[] = "han-id;entitlement[;country-mode]"
+; - han-id: ID that a licensed item (e.g. monograph, ebook package) is identified by at the KfL HAN Server.
+;   Note that there are special conventions for each FID that a han-id needs to start with (e.g. RelBib: rx-...).
+;   Also note that sometimes if a test license is created, it is only valid for 48 hours.
+; - entitlement is a license-related secret string that must be sent to the server when requesting access
+; - country-mode (optional): set this to "DACH" if you want to enable the country check for german-speaking countriers,
+    all other settings will disable the check.
+
+; Nomos "Strafrecht und Kriminologie" (e.g. 1898439737, 1898439729, 1898439710, and others => PPNs in eBook packages might change all the time)
+licenses[] = "kx-nomos;thisisnottherealentitlement;DACH"
+
+; Duncker & Humbloth (e.g. 1811373445, 1842927485, 1820279375, and others => PPNs in eBook packages might change all the time)
+licenses[] = "kx-duncker;thisisnottherealentitlement;DACH"


### PR DESCRIPTION
see also: ubtue/tuefind#3005