### PR TITLE
VuFind 11.0-related changes + more (JDK 17 => 21, PHP 8.3 => 8.4, refterm_solr_conf)

### DIFF
--- a/cpp/data/installer/scripts/install_ubuntu_packages.sh
+++ b/cpp/data/installer/scripts/install_ubuntu_packages.sh
@@ -84,14 +84,14 @@ if [[ $1 == "ixtheo" || $1 == "krimdok" ]]; then
     add-apt-repository --yes --update ppa:ondrej/php
     apt-get --quiet --yes install \
         composer npm node-grunt-cli \
-        php8.5 php8.5-curl php8.5-gd php8.5-intl php8.5-ldap php8.5-mbstring php8.5-memcached php8.5-mysql php8.5-soap php8.5-xml \
-        php8.5-fpm
+        php8.4 php8.4-curl php8.4-gd php8.4-intl php8.4-ldap php8.4-mbstring php8.4-memcached php8.4-mysql php8.4-soap php8.4-xml \
+        php8.4-fpm
 
     update-alternatives --set php /usr/bin/php8.3
 
     a2dismod mpm_prefork
     a2enmod mpm_event proxy_fcgi http2 rewrite setenvif ssl
-    a2enconf php8.5-fpm
+    a2enconf php8.4-fpm
     /etc/init.d/apache2 restart
 fi
 

--- a/cpp/data/installer/scripts/install_ubuntu_packages.sh
+++ b/cpp/data/installer/scripts/install_ubuntu_packages.sh
@@ -37,15 +37,15 @@ apt-get --quiet --yes --allow-unauthenticated install \
         ant apache2 apparmor-utils ca-certificates cifs-utils clang clang-format cron curl gcc git imagemagick incron ipset jq libarchive-dev \
         libboost-all-dev libcurl4-gnutls-dev libdb-dev liblept5 libleptonica-dev liblz4-tool libmagic-dev libmysqlclient-dev \
         libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libstemmer-dev libsystemd-dev libtesseract-dev libwebp7 libxerces-c-dev \
-        libxml2-dev libxml2-utils locales-all libxxhash-dev make mawk moreutils mpack mutt needrestart nlohmann-json3-dev openjdk-17-jdk p7zip-full \
-        poppler-utils postgresql-client python3 python3-paramiko rsync sqlite3 tesseract-ocr tesseract-ocr-all\
-        tcl-expect-dev tidy unzip uuid-dev xsltproc \
+        libxml2-dev libxml2-utils locales-all libxxhash-dev make mawk moreutils mpack mutt needrestart nlohmann-json3-dev openjdk-21-jdk p7zip-full \
+        poppler-utils postgresql-client python3 python3-paramiko rsync sqlite3 tesseract-ocr tesseract-ocr-all \
+        tcl-expect-dev tidy unzip uuid-dev xsltproc
 
 # Explicitly enable mod_cgi. If we would use `a2enmod cgi`, it would enable mod_cgid, which would fail on apache startup.
 a2enmod cgi
 
-# Set java version 17 to be kept manually (to avoid automatic migrations)
-update-java-alternatives --set java-1.17.0-openjdk-amd64
+# Set java version 21 to be kept manually (to avoid automatic migrations)
+update-java-alternatives --set java-1.21.0-openjdk-amd64
 
 #Install custom certificates
 mkdir --parents /usr/share/ca-certificates/custom
@@ -84,14 +84,14 @@ if [[ $1 == "ixtheo" || $1 == "krimdok" ]]; then
     add-apt-repository --yes --update ppa:ondrej/php
     apt-get --quiet --yes install \
         composer npm node-grunt-cli \
-        php8.3 php8.3-curl php8.3-gd php8.3-intl php8.3-ldap php8.3-mbstring php8.3-mysql php8.3-soap php8.3-xml \
-        php8.3-fpm
+        php8.5 php8.5-curl php8.5-gd php8.5-intl php8.5-ldap php8.5-mbstring php8.5-memcached php8.5-mysql php8.5-soap php8.5-xml \
+        php8.5-fpm
 
     update-alternatives --set php /usr/bin/php8.3
 
     a2dismod mpm_prefork
     a2enmod mpm_event proxy_fcgi http2 rewrite setenvif ssl
-    a2enconf php8.3-fpm
+    a2enconf php8.5-fpm
     /etc/init.d/apache2 restart
 fi
 

--- a/cpp/data/refterm_solr_conf/solr/vufind/biblio/conf/schema.xml
+++ b/cpp/data/refterm_solr_conf/solr/vufind/biblio/conf/schema.xml
@@ -1,72 +1,71 @@
 <?xml version="1.0" ?>
-<schema name="VuFind Bibliographic Index" version="1.2">
+<schema name="VuFind Bibliographic Index" version="1.7">
   <types>
-    <!-- Define fieldType long as it is needed by the _version_ field required by Solr 4.x -->
     <fieldType name="long" class="solr.LongPointField" positionIncrementGap="0"/>
-    <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
-    <fieldType name="textFacet" class="solr.TextField" sortMissingLast="true" omitNorms="true">
+    <fieldType name="string" class="solr.StrField" sortMissingLast="true"/>
+    <fieldType name="textFacet" class="solr.TextField" sortMissingLast="true" omitNorms="true" uninvertible="true">
       <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <tokenizer name="keyword"/>
         <!-- strip trailing punctuation from facets: -->
-        <filter class="solr.PatternReplaceFilterFactory" pattern="(?&lt;!\b[A-Z])[.\s]*$" replacement="" replace="first"/>
+        <filter name="patternReplace" pattern="(?&lt;!\b[A-Z])[.\s]*$" replacement="" replace="first"/>
       </analyzer>
     </fieldType>
     <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" splitOnNumerics="0"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+        <tokenizer name="icu"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" splitOnNumerics="0"/>
+        <filter name="icuFolding"/>
+        <filter name="keywordMarker" protected="protwords.txt"/>
         <filter class="solr.SnowballPorterFilterFactory" language="English"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
       <analyzer type="query">
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" splitOnNumerics="0"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+        <tokenizer name="icu"/>
+        <filter name="synonymGraph" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" splitOnNumerics="0"/>
+        <filter name="icuFolding"/>
+        <filter name="keywordMarker" protected="protwords.txt"/>
         <filter class="solr.SnowballPorterFilterFactory" language="English"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
     </fieldType>
     <!-- Text Field without Stemming and Synonyms -->
     <fieldType name="textProper" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnNumerics="0"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <tokenizer name="icu"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnNumerics="0"/>
+        <filter name="icuFolding"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
       <analyzer type="query">
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnNumerics="0"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <tokenizer name="icu"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnNumerics="0"/>
+        <filter name="icuFolding"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
     </fieldType>
     <!-- Basic Text Field for use with Spell Correction -->
     <fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnNumerics="0"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <tokenizer name="icu"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnNumerics="0"/>
+        <filter name="icuFolding"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
     </fieldType>
     <!-- More advanced spell checking field. -->
     <fieldType name="textSpellShingle" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.ShingleFilterFactory" maxShingleSize="2" outputUnigrams="false"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <tokenizer name="icu"/>
+        <filter name="icuFolding"/>
+        <filter name="shingle" maxShingleSize="2" outputUnigrams="false"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
       <analyzer type="query">
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.ShingleFilterFactory" maxShingleSize="2" outputUnigrams="false"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <tokenizer name="icu"/>
+        <filter name="icuFolding"/>
+        <filter name="shingle" maxShingleSize="2" outputUnigrams="false"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
     </fieldType>
     <!-- Text Field for Normalized ISBN/ISSN Numbers - take first chunk of text
@@ -74,38 +73,41 @@
          omit results that are empty after stripping. -->
     <fieldType name="isn" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
-        <tokenizer class="solr.PatternTokenizerFactory" pattern="^(\S*)\s*.*$" group="1"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.PatternReplaceFilterFactory" pattern="[^0-9x]" replacement="" replace="all"/>
-        <filter class="solr.LengthFilterFactory" min="4" max="100"/>
+        <tokenizer name="pattern" pattern="^(\S*)\s*.*$" group="1"/>
+        <filter name="lowercase"/>
+        <filter name="patternReplace" pattern="[^0-9x]" replacement="" replace="all"/>
+        <filter name="length" min="4" max="100" />
       </analyzer>
     </fieldType>
     <!-- case-insensitive/whitespace-agnostic field type for callnumber searching -->
     <fieldType name="callnumberSearch" class="solr.TextField" sortMissingLast="true" omitNorms="true">
       <analyzer>
-        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\s)" replacement=""/>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
+        <charFilter name="patternReplace" pattern="(\s)" replacement=""/>
+        <tokenizer name="keyword"/>
+        <filter name="icuFolding"/>
       </analyzer>
     </fieldType>
     <!-- Field for SolrPrefix autocomplete -->
     <fieldType name="text_autocomplete" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
       <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.EdgeNGramFilterFactory" minGramSize="1" maxGramSize="25"/>
+        <tokenizer name="whitespace"/>
+        <filter name="icuFolding"/>
+        <filter name="edgeNGram" minGramSize="1" maxGramSize="25" />
       </analyzer>
       <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
+        <tokenizer name="whitespace"/>
+        <filter name="icuFolding"/>
       </analyzer>
     </fieldType>
     <fieldType name="date" class="solr.DatePointField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="dateRange" class="solr.DateRangeField" sortMissingLast="true" uninvertible="false"/>
     <fieldType name="random" class="solr.RandomSortField" indexed="true"/>
     <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
+    <!-- add geo field to handle geographic search and display capabilities -->
+    <fieldType name="geo" class="solr.SpatialRecursivePrefixTreeFieldType" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees" />
   </types>
  <fields>
-   <!-- Required by Solr 4.x -->
+   <!-- Required by Solr -->
    <field name="_version_" type="long" indexed="true" stored="true"/>
    <!-- Core Fields  -->
    <field name="id" type="string" indexed="true" stored="true"/>


### PR DESCRIPTION
- JDK 21 already rolled out
- PHP 8.4 will be combined with the VuFind 11.0 migration (Note: We will only migrate to 8.4 instead of 8.5, since VuFind 11.0 only performs CI against 8.4; 8.5 will be postponed at least until VuFind 11.1)
- refterm_solr_conf-related changes to VuFind 11.0