### PR TITLE
Downloader: Use cookies across multiple downloader instances

### DIFF
--- a/cpp/lib/include/Downloader.h
+++ b/cpp/lib/include/Downloader.h
@@ -101,7 +101,8 @@ public:
         std::string authentication_username_;
         std::string authentication_password_;
         bool use_cookies_txt_;
-        std::string cookies_txt_path_;
+        std::string
+            cookies_txt_path_; // default empty = RAM only, set this to a specific file path to share cookies across instances+processes
         bool fail_on_error_;
 
     public:
@@ -114,8 +115,7 @@ public:
                         const bool ignore_ssl_certificates = false, const std::string &proxy_host_and_port = "",
                         const std::vector<std::string> &additional_headers = {}, const std::string &post_data = "",
                         const std::string &authentication_username = "", const std::string &authentication_password = "",
-                        const bool use_cookies_txt = true, const std::string cookies_txt_path = "/tmp/cookies.txt",
-                        const bool fail_on_error = true);
+                        const bool use_cookies_txt = true, const std::string cookies_txt_path = "", const bool fail_on_error = true);
     };
 
     typedef size_t (*WriteFunc)(void *data, size_t size, size_t nmemb, void *this_pointer);

--- a/cpp/lib/include/Downloader.h
+++ b/cpp/lib/include/Downloader.h
@@ -101,6 +101,7 @@ public:
         std::string authentication_username_;
         std::string authentication_password_;
         bool use_cookies_txt_;
+        std::string cookies_txt_path_;
         bool fail_on_error_;
 
     public:
@@ -113,7 +114,8 @@ public:
                         const bool ignore_ssl_certificates = false, const std::string &proxy_host_and_port = "",
                         const std::vector<std::string> &additional_headers = {}, const std::string &post_data = "",
                         const std::string &authentication_username = "", const std::string &authentication_password = "",
-                        const bool use_cookies_txt = true, const bool fail_on_error = true);
+                        const bool use_cookies_txt = true, const std::string cookies_txt_path = "/tmp/cookies.txt",
+                        const bool fail_on_error = true);
     };
 
     typedef size_t (*WriteFunc)(void *data, size_t size, size_t nmemb, void *this_pointer);

--- a/cpp/lib/src/Downloader.cc
+++ b/cpp/lib/src/Downloader.cc
@@ -401,8 +401,9 @@ void Downloader::init() {
 
     if (params_.use_cookies_txt_) /*Use local cookie storage only*/ {
         // Use same store for reading and writing, thus we are to mimic browser behaviour and send back received cookies
-        curlEasySetopt(CURLOPT_COOKIEFILE, "", "Download::init::CURLOPT_COOKIEFILE");
-        curlEasySetopt(CURLOPT_COOKIEJAR, "", "Download::init::CURLOPT_COOKIEJAR");
+        const std::string cookies_txt_path("/tmp/cookies.txt");
+        curlEasySetopt(CURLOPT_COOKIEFILE, cookies_txt_path.c_str(), "Downloader::init::CURLOPT_COOKIEFILE");
+        curlEasySetopt(CURLOPT_COOKIEJAR, cookies_txt_path.c_str(), "Downloader::init::CURLOPT_COOKIEJAR");
     }
 }
 

--- a/cpp/lib/src/Downloader.cc
+++ b/cpp/lib/src/Downloader.cc
@@ -134,14 +134,15 @@ Downloader::Params::Params(const std::string &user_agent, const std::string &acc
                            const unsigned meta_redirect_threshold, const bool ignore_ssl_certificates,
                            const std::string &proxy_host_and_port, const std::vector<std::string> &additional_headers,
                            const std::string &post_data, const std::string &authentication_username,
-                           const std::string &authentication_password, const bool use_cookies_txt, const bool fail_on_error)
+                           const std::string &authentication_password, const bool use_cookies_txt, const std::string cookies_txt_path,
+                           const bool fail_on_error)
     : user_agent_(user_agent), acceptable_languages_(acceptable_languages), max_redirect_count_(max_redirect_count),
       dns_cache_timeout_(dns_cache_timeout), honour_robots_dot_txt_(honour_robots_dot_txt), text_translation_mode_(text_translation_mode),
       banned_reg_exps_(banned_reg_exps), debugging_(debugging), follow_redirects_(follow_redirects),
       meta_redirect_threshold_(meta_redirect_threshold), ignore_ssl_certificates_(ignore_ssl_certificates),
       proxy_host_and_port_(proxy_host_and_port), additional_headers_(additional_headers), post_data_(post_data),
       authentication_username_(authentication_username), authentication_password_(authentication_password),
-      use_cookies_txt_(use_cookies_txt), fail_on_error_(fail_on_error) {
+      use_cookies_txt_(use_cookies_txt), cookies_txt_path_(cookies_txt_path), fail_on_error_(fail_on_error) {
     max_redirect_count_ = follow_redirects_ ? max_redirect_count_ : 0;
 
     if (unlikely(max_redirect_count_ < 0 or max_redirect_count_ > MAX_MAX_REDIRECT_COUNT))
@@ -401,9 +402,10 @@ void Downloader::init() {
 
     if (params_.use_cookies_txt_) /*Use local cookie storage only*/ {
         // Use same store for reading and writing, thus we are to mimic browser behaviour and send back received cookies
-        const std::string cookies_txt_path("/tmp/cookies.txt");
-        curlEasySetopt(CURLOPT_COOKIEFILE, cookies_txt_path.c_str(), "Downloader::init::CURLOPT_COOKIEFILE");
-        curlEasySetopt(CURLOPT_COOKIEJAR, cookies_txt_path.c_str(), "Downloader::init::CURLOPT_COOKIEJAR");
+        // Note that if cookies_txt_path_ is an empty string / no explicit path is given,
+        // cookies will only be re-used within the same downloader object instance.
+        curlEasySetopt(CURLOPT_COOKIEFILE, params_.cookies_txt_path_.c_str(), "Downloader::init::CURLOPT_COOKIEFILE");
+        curlEasySetopt(CURLOPT_COOKIEJAR, params_.cookies_txt_path_.c_str(), "Downloader::init::CURLOPT_COOKIEJAR");
     }
 }
 

--- a/cpp/test/downloader_test.cc
+++ b/cpp/test/downloader_test.cc
@@ -27,7 +27,7 @@
 
 void Usage() {
     std::cerr << "Usage: " << progname
-              << " [--timeout milli_seconds] [--honour-robots-dot-txt] [--ignore-ssl-certificates] url1 [url2 urln]\n";
+              << " [--timeout milli_seconds] [--honour-robots-dot-txt] [--ignore-ssl-certificates] [--verbose] url1 [url2 urln]\n";
     std::exit(EXIT_FAILURE);
 }
 
@@ -62,6 +62,17 @@ int main(int argc, char *argv[]) {
         params.ignore_ssl_certificates_ = true;
         --argc, ++argv;
     }
+
+    if (argc < 2)
+        Usage();
+
+    if (std::strcmp(argv[1], "--verbose") == 0) {
+        params.debugging_ = true;
+        --argc, ++argv;
+    }
+
+    if (argc < 2)
+        Usage();
 
     // Make sure the same Downloader object is re-used for all URLs,
     // this way we can e.g. check whether Cookies are set correctly


### PR DESCRIPTION
After enabling debugging_ = true, before this change:

> 2026-06-12T09:09:05 INFO extract_keywords_for_translation: in void Downloader::debugFunction(CURL *, curl_infotype, char *, size_t) --> informational text: WARNING: failed to save cookies in : Failed writing received data to disk/application

It would work within downloader_test before though if you call it once via shell and pass multiple urls, but if you call it seperately it won't. Also, before this change it depended on whether there is only 1 downloader object being created and re-used, or a new object being created for each download.

**Example 1)**
Works before the change: (As one-liner, because [implementation re-uses same downloader instance](https://github.com/ubtue/ub_tools/blob/4d892df0857eeca323140f6264f2880da8d857d4/cpp/test/downloader_test.cc#L73))
```
downloader_test 'https://httpbin.dev/cookies/set?foo=bar' 'https://httpbin.dev/cookies/set'
```
Did not work before the change:
```
downloader_test 'https://httpbin.dev/cookies/set?foo=bar'
downloader_test 'https://httpbin.dev/cookies/set'
```

**Example 2)**
extract_keywords_for_translation: Does not re-use cookies before the change, since a [new downloader is initialized for every single query](https://github.com/ubtue/ub_tools/blob/4d892df0857eeca323140f6264f2880da8d857d4/cpp/pipelines/extract_keywords_for_translation.cc#L229)